### PR TITLE
[Task 4.2] API 에러 핸들링 및 응답 표준화

### DIFF
--- a/apps/api/src/common/http-exception.filter.ts
+++ b/apps/api/src/common/http-exception.filter.ts
@@ -5,8 +5,11 @@ import {
   HttpException,
   HttpStatus,
   Logger,
+  BadRequestException,
 } from "@nestjs/common";
 import type { Response } from "express";
+import { QueryFailedError } from "typeorm";
+import type { ApiResponse } from "./interfaces/api-response.interface";
 
 @Catch()
 export class GlobalExceptionFilter implements ExceptionFilter {
@@ -16,27 +19,171 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
 
-    let status = HttpStatus.INTERNAL_SERVER_ERROR;
-    let message = "서버 오류가 발생했습니다.";
+    const { status, body } = this.buildResponse(exception);
 
-    if (exception instanceof HttpException) {
-      status = exception.getStatus();
-      const exceptionResponse = exception.getResponse();
-      message =
-        typeof exceptionResponse === "string"
-          ? exceptionResponse
-          : (exceptionResponse as Record<string, unknown>).message as string ??
-            exception.message;
-    } else if (exception instanceof Error) {
-      this.logger.error(`Unhandled error: ${exception.message}`, exception.stack);
-    } else {
-      this.logger.error(`Unknown error: ${String(exception)}`);
+    response.status(status).json(body);
+  }
+
+  private buildResponse(exception: unknown): {
+    status: number;
+    body: ApiResponse;
+  } {
+    if (exception instanceof BadRequestException) {
+      return this.handleValidationError(exception);
     }
 
-    response.status(status).json({
-      statusCode: status,
-      message: Array.isArray(message) ? message.join(", ") : message,
-      timestamp: new Date().toISOString(),
-    });
+    if (exception instanceof HttpException) {
+      return this.handleHttpException(exception);
+    }
+
+    if (exception instanceof QueryFailedError) {
+      return this.handleQueryFailedError(exception);
+    }
+
+    if (exception instanceof Error) {
+      this.logger.error(
+        `Unhandled error: ${exception.message}`,
+        exception.stack,
+      );
+      return {
+        status: HttpStatus.INTERNAL_SERVER_ERROR,
+        body: {
+          success: false,
+          error: {
+            code: "INTERNAL_ERROR",
+            message: "서버 오류가 발생했습니다.",
+          },
+        },
+      };
+    }
+
+    this.logger.error(`Unknown error: ${String(exception)}`);
+    return {
+      status: HttpStatus.INTERNAL_SERVER_ERROR,
+      body: {
+        success: false,
+        error: {
+          code: "UNKNOWN_ERROR",
+          message: "알 수 없는 오류가 발생했습니다.",
+        },
+      },
+    };
+  }
+
+  private handleValidationError(exception: BadRequestException): {
+    status: number;
+    body: ApiResponse;
+  } {
+    const status = exception.getStatus();
+    const exceptionResponse = exception.getResponse();
+
+    let message: string;
+    if (typeof exceptionResponse === "object" && exceptionResponse !== null) {
+      const resp = exceptionResponse as Record<string, unknown>;
+      const msg = resp.message;
+      message = Array.isArray(msg) ? (msg as string[]).join(", ") : String(msg);
+    } else {
+      message = String(exceptionResponse);
+    }
+
+    return {
+      status,
+      body: {
+        success: false,
+        error: {
+          code: "VALIDATION_ERROR",
+          message,
+        },
+      },
+    };
+  }
+
+  private handleHttpException(exception: HttpException): {
+    status: number;
+    body: ApiResponse;
+  } {
+    const status = exception.getStatus();
+    const exceptionResponse = exception.getResponse();
+
+    let message: string;
+    if (typeof exceptionResponse === "string") {
+      message = exceptionResponse;
+    } else if (
+      typeof exceptionResponse === "object" &&
+      exceptionResponse !== null
+    ) {
+      const resp = exceptionResponse as Record<string, unknown>;
+      const msg = resp.message;
+      message = Array.isArray(msg)
+        ? (msg as string[]).join(", ")
+        : typeof msg === "string"
+          ? msg
+          : exception.message;
+    } else {
+      message = exception.message;
+    }
+
+    return {
+      status,
+      body: {
+        success: false,
+        error: {
+          code: `HTTP_${status}`,
+          message,
+        },
+      },
+    };
+  }
+
+  private handleQueryFailedError(exception: QueryFailedError): {
+    status: number;
+    body: ApiResponse;
+  } {
+    this.logger.error(
+      `Database query failed: ${exception.message}`,
+      exception.stack,
+    );
+
+    const driverError = exception.driverError as Record<string, unknown> | undefined;
+    const pgCode = driverError?.code as string | undefined;
+
+    // PostgreSQL unique violation
+    if (pgCode === "23505") {
+      return {
+        status: HttpStatus.CONFLICT,
+        body: {
+          success: false,
+          error: {
+            code: "DUPLICATE_ENTRY",
+            message: "이미 존재하는 데이터입니다.",
+          },
+        },
+      };
+    }
+
+    // PostgreSQL foreign key violation
+    if (pgCode === "23503") {
+      return {
+        status: HttpStatus.BAD_REQUEST,
+        body: {
+          success: false,
+          error: {
+            code: "FOREIGN_KEY_VIOLATION",
+            message: "참조하는 데이터가 존재하지 않습니다.",
+          },
+        },
+      };
+    }
+
+    return {
+      status: HttpStatus.INTERNAL_SERVER_ERROR,
+      body: {
+        success: false,
+        error: {
+          code: "DATABASE_ERROR",
+          message: "데이터베이스 오류가 발생했습니다.",
+        },
+      },
+    };
   }
 }

--- a/apps/api/src/common/interceptors/transform.interceptor.ts
+++ b/apps/api/src/common/interceptors/transform.interceptor.ts
@@ -1,0 +1,26 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from "@nestjs/common";
+import { Observable } from "rxjs";
+import { map } from "rxjs/operators";
+import type { ApiResponse } from "../interfaces/api-response.interface";
+
+@Injectable()
+export class TransformInterceptor<T>
+  implements NestInterceptor<T, ApiResponse<T>>
+{
+  intercept(
+    _context: ExecutionContext,
+    next: CallHandler<T>,
+  ): Observable<ApiResponse<T>> {
+    return next.handle().pipe(
+      map((data) => ({
+        success: true,
+        data,
+      })),
+    );
+  }
+}

--- a/apps/api/src/common/interfaces/api-response.interface.ts
+++ b/apps/api/src/common/interfaces/api-response.interface.ts
@@ -1,0 +1,10 @@
+export interface ApiErrorDetail {
+  code: string;
+  message: string;
+}
+
+export interface ApiResponse<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: ApiErrorDetail;
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,7 +1,8 @@
 import { NestFactory } from "@nestjs/core";
-import { Logger } from "@nestjs/common";
+import { Logger, ValidationPipe } from "@nestjs/common";
 import { AppModule } from "./app.module";
 import { GlobalExceptionFilter } from "./common/http-exception.filter";
+import { TransformInterceptor } from "./common/interceptors/transform.interceptor";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
@@ -9,7 +10,15 @@ async function bootstrap() {
   });
   app.enableCors();
   app.setGlobalPrefix("api");
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
   app.useGlobalFilters(new GlobalExceptionFilter());
+  app.useGlobalInterceptors(new TransformInterceptor());
 
   const port = process.env.PORT || 4000;
   await app.listen(port);


### PR DESCRIPTION
## Summary
- GlobalExceptionFilter 강화: TypeORM QueryFailedError, ValidationPipe 에러 처리
- TransformInterceptor 추가: 모든 응답을 `{ success, data?, error? }` 형식으로 표준화
- ValidationPipe 글로벌 등록 (whitelist, transform)

## Changes
- `apps/api/src/common/interfaces/api-response.interface.ts` (신규)
- `apps/api/src/common/interceptors/transform.interceptor.ts` (신규)
- `apps/api/src/common/http-exception.filter.ts` (강화)
- `apps/api/src/main.ts` (인터셉터/파이프 등록)

Closes #24

https://claude.ai/code/session_01Hfi6bb581xcUz4Zpf8r5iE