### PR TITLE
[Task 1.3] 청약 자격-공고 자동 매칭 로직 구현

### DIFF
--- a/apps/api/src/announcement/announcement.controller.ts
+++ b/apps/api/src/announcement/announcement.controller.ts
@@ -1,5 +1,16 @@
-import { Controller, Get, Param, Query, ParseIntPipe, NotFoundException } from "@nestjs/common";
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Query,
+  Body,
+  ParseIntPipe,
+  NotFoundException,
+  BadRequestException,
+} from "@nestjs/common";
 import { AnnouncementService } from "./announcement.service";
+import { matchRequestSchema } from "./dto/match-request.dto";
 
 @Controller("announcements")
 export class AnnouncementController {
@@ -25,6 +36,28 @@ export class AnnouncementController {
   @Get(":id")
   async findOne(@Param("id", ParseIntPipe) id: number) {
     const result = await this.announcementService.findOne(id);
+    if (!result) {
+      throw new NotFoundException("공고를 찾을 수 없습니다.");
+    }
+    return result;
+  }
+
+  @Post(":id/match")
+  async matchAnnouncement(
+    @Param("id", ParseIntPipe) id: number,
+    @Body() body: unknown,
+  ) {
+    const parsed = matchRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new BadRequestException(
+        parsed.error.issues.map((i) => i.message).join(", "),
+      );
+    }
+
+    const result = await this.announcementService.matchAnnouncement(
+      id,
+      parsed.data,
+    );
     if (!result) {
       throw new NotFoundException("공고를 찾을 수 없습니다.");
     }

--- a/apps/api/src/announcement/announcement.module.ts
+++ b/apps/api/src/announcement/announcement.module.ts
@@ -1,11 +1,11 @@
 import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
-import { Announcement } from "@zipath/db";
+import { Announcement, SubscriptionCriteria } from "@zipath/db";
 import { AnnouncementController } from "./announcement.controller";
 import { AnnouncementService } from "./announcement.service";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Announcement])],
+  imports: [TypeOrmModule.forFeature([Announcement, SubscriptionCriteria])],
   controllers: [AnnouncementController],
   providers: [AnnouncementService],
 })

--- a/apps/api/src/announcement/announcement.service.ts
+++ b/apps/api/src/announcement/announcement.service.ts
@@ -2,8 +2,10 @@ import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
-import { Announcement } from "@zipath/db";
+import { Announcement, SubscriptionCriteria } from "@zipath/db";
 import { Cron } from "@nestjs/schedule";
+import { MatchRequestDto } from "./dto/match-request.dto";
+import { MatchResultDto, MatchCriterionResult } from "./dto/match-result.dto";
 
 interface ApiAnnouncement {
   HOUSE_MANAGE_NO: string;
@@ -29,6 +31,8 @@ export class AnnouncementService {
   constructor(
     @InjectRepository(Announcement)
     private readonly announcementRepo: Repository<Announcement>,
+    @InjectRepository(SubscriptionCriteria)
+    private readonly criteriaRepo: Repository<SubscriptionCriteria>,
     private readonly config: ConfigService,
   ) {}
 
@@ -142,6 +146,152 @@ export class AnnouncementService {
         `동기화 실패: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
+  }
+
+  /** 사용자 입력과 공고 요건 자동 매칭 */
+  async matchAnnouncement(
+    announcementId: number,
+    input: MatchRequestDto,
+  ): Promise<MatchResultDto | null> {
+    const announcement = await this.announcementRepo.findOne({
+      where: { id: announcementId },
+    });
+    if (!announcement) return null;
+
+    // 해당 공고의 청약 기준 조회 (DB에 저장된 기준이 있으면 활용)
+    const criteriaQb = this.criteriaRepo.createQueryBuilder("c");
+    if (announcement.region) {
+      criteriaQb.where("c.region = :region OR c.region IS NULL", {
+        region: announcement.region,
+      });
+    }
+    const criteria = await criteriaQb.getMany();
+
+    const results: MatchCriterionResult[] = [];
+
+    if (criteria.length > 0) {
+      // DB에 저장된 기준이 있는 경우 각 기준별로 매칭
+      for (const criterion of criteria) {
+        const reasons: string[] = [];
+        let eligible = true;
+
+        if (criterion.minAge !== null && input.age < criterion.minAge) {
+          eligible = false;
+          reasons.push(`나이 ${criterion.minAge}세 이상 필요 (현재 ${input.age}세)`);
+        }
+
+        if (
+          criterion.maxIncome !== null &&
+          input.income > criterion.maxIncome
+        ) {
+          eligible = false;
+          reasons.push(
+            `소득 ${criterion.maxIncome}만원 이하 필요 (현재 ${input.income}만원)`,
+          );
+        }
+
+        if (
+          criterion.minHomeless !== null &&
+          input.homelessMonths < criterion.minHomeless
+        ) {
+          eligible = false;
+          reasons.push(
+            `무주택 기간 ${criterion.minHomeless}개월 이상 필요 (현재 ${input.homelessMonths}개월)`,
+          );
+        }
+
+        if (
+          criterion.region !== null &&
+          input.region &&
+          criterion.region !== input.region
+        ) {
+          eligible = false;
+          reasons.push(
+            `지역 불일치 (요구: ${criterion.region}, 입력: ${input.region})`,
+          );
+        }
+
+        results.push({
+          criterion: criterion.type,
+          eligible,
+          reason: eligible
+            ? "자격 요건 충족"
+            : reasons.join("; "),
+        });
+      }
+    } else {
+      // DB에 기준이 없으면 기본 로직으로 판별 (subscription 서비스 패턴 참고)
+      results.push(
+        ...this.applyDefaultCriteria(announcement, input),
+      );
+    }
+
+    const overallEligible = results.some((r) => r.eligible);
+
+    return {
+      announcementId: announcement.id,
+      announcementTitle: announcement.title,
+      overallEligible,
+      results,
+      message: overallEligible
+        ? "해당 공고에 지원 가능한 유형이 있습니다!"
+        : "현재 조건으로는 해당 공고 지원이 어렵습니다.",
+    };
+  }
+
+  /** DB에 기준이 없을 때 기본 판별 로직 */
+  private applyDefaultCriteria(
+    announcement: Announcement,
+    input: MatchRequestDto,
+  ): MatchCriterionResult[] {
+    const results: MatchCriterionResult[] = [];
+
+    // 지역 매칭 확인
+    const regionMatch =
+      !input.region || announcement.region === input.region;
+
+    // 1순위 일반
+    if (input.age >= 19 && input.homelessMonths >= 24 && input.income <= 6000) {
+      results.push({
+        criterion: "1순위 일반",
+        eligible: regionMatch,
+        reason: regionMatch
+          ? "기본 자격 충족"
+          : `지역 불일치 (공고: ${announcement.region}, 입력: ${input.region})`,
+      });
+    } else {
+      const reasons: string[] = [];
+      if (input.age < 19) reasons.push("만 19세 미만");
+      if (input.homelessMonths < 24) reasons.push("무주택 기간 24개월 미만");
+      if (input.income > 6000) reasons.push("소득 기준 초과");
+      results.push({
+        criterion: "1순위 일반",
+        eligible: false,
+        reason: reasons.join("; "),
+      });
+    }
+
+    // 특별공급 - 신혼부부
+    if (input.income <= 7000) {
+      results.push({
+        criterion: "특별공급 (신혼부부)",
+        eligible: regionMatch,
+        reason: regionMatch ? "소득 기준 충족" : `지역 불일치`,
+      });
+    }
+
+    // 특별공급 - 생애최초
+    if (input.homelessMonths >= 0 && input.income <= 6000) {
+      results.push({
+        criterion: "특별공급 (생애최초)",
+        eligible: regionMatch,
+        reason: regionMatch
+          ? "무주택 + 소득 기준 충족"
+          : `지역 불일치`,
+      });
+    }
+
+    return results;
   }
 
   private parseDate(dateStr: string): Date {

--- a/apps/api/src/announcement/dto/match-request.dto.ts
+++ b/apps/api/src/announcement/dto/match-request.dto.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const matchRequestSchema = z.object({
+  age: z.number().int().min(0).max(150),
+  income: z.number().min(0), // 만원 단위
+  homelessMonths: z.number().int().min(0),
+  region: z.string().optional(),
+});
+
+export type MatchRequestDto = z.infer<typeof matchRequestSchema>;

--- a/apps/api/src/announcement/dto/match-result.dto.ts
+++ b/apps/api/src/announcement/dto/match-result.dto.ts
@@ -1,0 +1,13 @@
+export interface MatchCriterionResult {
+  criterion: string;
+  eligible: boolean;
+  reason: string;
+}
+
+export interface MatchResultDto {
+  announcementId: number;
+  announcementTitle: string;
+  overallEligible: boolean;
+  results: MatchCriterionResult[];
+  message: string;
+}


### PR DESCRIPTION
## Summary
- POST /announcements/:id/match 엔드포인트 추가
- 사용자 입력(나이, 소득, 무주택기간, 지역)과 공고 요구사항 비교
- SubscriptionCriteria DB 기반 매칭 + 기본 로직 fallback
- Zod 검증 DTO (match-request.dto.ts, match-result.dto.ts)

Closes #15

https://claude.ai/code/session_01Hfi6bb581xcUz4Zpf8r5iE