### PR TITLE
[Task 3.1] 월별 가격 추이 차트 구현

### DIFF
--- a/apps/api/src/real-price/real-price.controller.ts
+++ b/apps/api/src/real-price/real-price.controller.ts
@@ -7,6 +7,12 @@ const searchSchema = z.object({
   yearMonth: z.string().regex(/^\d{6}$/, "YYYYMM 형식이어야 합니다"),
 });
 
+const trendSchema = z.object({
+  regionCode: z.string().min(5).max(5),
+  fromMonth: z.string().regex(/^\d{6}$/, "YYYYMM 형식이어야 합니다"),
+  toMonth: z.string().regex(/^\d{6}$/, "YYYYMM 형식이어야 합니다"),
+});
+
 @Controller("real-price")
 export class RealPriceController {
   constructor(private readonly realPriceService: RealPriceService) {}
@@ -23,5 +29,24 @@ export class RealPriceController {
       );
     }
     return this.realPriceService.search(parsed.data.regionCode, parsed.data.yearMonth);
+  }
+
+  @Get("trend")
+  async trend(
+    @Query("regionCode") regionCode: string,
+    @Query("fromMonth") fromMonth: string,
+    @Query("toMonth") toMonth: string,
+  ) {
+    const parsed = trendSchema.safeParse({ regionCode, fromMonth, toMonth });
+    if (!parsed.success) {
+      throw new BadRequestException(
+        parsed.error.issues.map((i) => i.message).join(", "),
+      );
+    }
+    return this.realPriceService.searchRange(
+      parsed.data.regionCode,
+      parsed.data.fromMonth,
+      parsed.data.toMonth,
+    );
   }
 }

--- a/apps/api/src/real-price/real-price.service.ts
+++ b/apps/api/src/real-price/real-price.service.ts
@@ -3,7 +3,7 @@ import { ConfigService } from "@nestjs/config";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { RealPriceCache } from "@zipath/db";
-import type { RealPriceTrade } from "@zipath/types";
+import type { RealPriceTrade, MonthlyPriceSummary } from "@zipath/types";
 
 @Injectable()
 export class RealPriceService {
@@ -74,6 +74,59 @@ export class RealPriceService {
       regionCode,
       yearMonth,
     };
+  }
+
+  async searchRange(regionCode: string, fromMonth: string, toMonth: string) {
+    const months = this.generateMonthRange(fromMonth, toMonth);
+    const results = await Promise.all(
+      months.map((m) => this.search(regionCode, m)),
+    );
+
+    const monthly: MonthlyPriceSummary[] = results.map((r) => {
+      const prices = r.trades
+        .map((t) => parseInt(t.dealAmount?.replace(/,/g, "").trim() || "0", 10))
+        .filter((p) => p > 0);
+
+      const avg =
+        prices.length > 0
+          ? Math.round(prices.reduce((a, b) => a + b, 0) / prices.length)
+          : 0;
+      const min = prices.length > 0 ? Math.min(...prices) : 0;
+      const max = prices.length > 0 ? Math.max(...prices) : 0;
+
+      return {
+        yearMonth: r.yearMonth,
+        avgPrice: avg,
+        minPrice: min,
+        maxPrice: max,
+        tradeCount: prices.length,
+      };
+    });
+
+    return {
+      regionCode,
+      fromMonth,
+      toMonth,
+      monthly,
+    };
+  }
+
+  private generateMonthRange(from: string, to: string): string[] {
+    const months: string[] = [];
+    let year = parseInt(from.slice(0, 4), 10);
+    let month = parseInt(from.slice(4, 6), 10);
+    const toYear = parseInt(to.slice(0, 4), 10);
+    const toMonth = parseInt(to.slice(4, 6), 10);
+
+    while (year < toYear || (year === toYear && month <= toMonth)) {
+      months.push(`${year}${String(month).padStart(2, "0")}`);
+      month++;
+      if (month > 12) {
+        month = 1;
+        year++;
+      }
+    }
+    return months;
   }
 
   private async fetchFromApi(

--- a/apps/web/src/app/api/real-price/trend/route.ts
+++ b/apps/web/src/app/api/real-price/trend/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000/api";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const regionCode = searchParams.get("regionCode");
+  const fromMonth = searchParams.get("fromMonth");
+  const toMonth = searchParams.get("toMonth");
+
+  if (!regionCode || !fromMonth || !toMonth) {
+    return NextResponse.json(
+      { error: "regionCode, fromMonth, and toMonth are required" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const res = await fetch(
+      `${API_BASE}/real-price/trend?regionCode=${regionCode}&fromMonth=${fromMonth}&toMonth=${toMonth}`,
+    );
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => null);
+      return NextResponse.json(
+        {
+          error:
+            (body as Record<string, string>)?.message ??
+            `Backend error: ${res.status}`,
+        },
+        { status: res.status },
+      );
+    }
+
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to fetch trend data" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/real-price/_components/MonthlyPriceTrendChart.tsx
+++ b/apps/web/src/app/real-price/_components/MonthlyPriceTrendChart.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import {
+  LineChart,
+  Line,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
+
+interface MonthlyPriceSummary {
+  yearMonth: string;
+  avgPrice: number;
+  minPrice: number;
+  maxPrice: number;
+  tradeCount: number;
+}
+
+interface MonthlyPriceTrendChartProps {
+  data: MonthlyPriceSummary[];
+  loading: boolean;
+}
+
+type ChartMode = "avg" | "range";
+
+function formatYearMonth(ym: string): string {
+  const year = ym.slice(0, 4);
+  const month = ym.slice(4, 6);
+  return `${year}.${month}`;
+}
+
+function formatPrice(value: number): string {
+  if (value >= 10000) {
+    const eok = Math.floor(value / 10000);
+    const remainder = value % 10000;
+    if (remainder === 0) return `${eok}억`;
+    return `${eok}억 ${remainder.toLocaleString()}`;
+  }
+  return `${value.toLocaleString()}만원`;
+}
+
+import { useState } from "react";
+
+export default function MonthlyPriceTrendChart({
+  data,
+  loading,
+}: MonthlyPriceTrendChartProps) {
+  const [chartMode, setChartMode] = useState<ChartMode>("avg");
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-20">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (data.length === 0) {
+    return (
+      <div className="rounded-lg border p-6 text-center text-muted-foreground">
+        조회된 추이 데이터가 없습니다. 지역과 기간을 선택 후 조회해주세요.
+      </div>
+    );
+  }
+
+  const chartData = data.map((d) => ({
+    ...d,
+    label: formatYearMonth(d.yearMonth),
+  }));
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold">월별 가격 추이</h3>
+        <div className="flex gap-2">
+          <button
+            onClick={() => setChartMode("avg")}
+            className={`rounded px-3 py-1 text-xs font-medium transition-colors ${
+              chartMode === "avg"
+                ? "bg-primary text-primary-foreground"
+                : "border hover:bg-accent"
+            }`}
+          >
+            평균가
+          </button>
+          <button
+            onClick={() => setChartMode("range")}
+            className={`rounded px-3 py-1 text-xs font-medium transition-colors ${
+              chartMode === "range"
+                ? "bg-primary text-primary-foreground"
+                : "border hover:bg-accent"
+            }`}
+          >
+            가격 범위
+          </button>
+        </div>
+      </div>
+
+      <div className="rounded-lg border bg-card p-4">
+        <ResponsiveContainer width="100%" height={350}>
+          {chartMode === "avg" ? (
+            <LineChart data={chartData} margin={{ top: 5, right: 20, bottom: 5, left: 20 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis
+                dataKey="label"
+                tick={{ fontSize: 12 }}
+                interval="preserveStartEnd"
+              />
+              <YAxis
+                tickFormatter={(v: number) => {
+                  if (v >= 10000) return `${(v / 10000).toFixed(1)}억`;
+                  return `${v.toLocaleString()}`;
+                }}
+                tick={{ fontSize: 12 }}
+                width={70}
+              />
+              <Tooltip
+                formatter={(value: unknown, name: unknown) => {
+                  const v = Number(value);
+                  const n = String(name);
+                  if (n === "avgPrice") return [formatPrice(v), "평균가"];
+                  if (n === "tradeCount") return [`${v}건`, "거래 건수"];
+                  return [formatPrice(v), n];
+                }}
+                labelFormatter={(label: unknown) => String(label)}
+              />
+              <Legend
+                formatter={(value: unknown) => {
+                  const v = String(value);
+                  if (v === "avgPrice") return "평균가";
+                  if (v === "tradeCount") return "거래 건수";
+                  return v;
+                }}
+              />
+              <Line
+                type="monotone"
+                dataKey="avgPrice"
+                stroke="hsl(221, 83%, 53%)"
+                strokeWidth={2}
+                dot={{ r: 4 }}
+                activeDot={{ r: 6 }}
+              />
+            </LineChart>
+          ) : (
+            <AreaChart data={chartData} margin={{ top: 5, right: 20, bottom: 5, left: 20 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis
+                dataKey="label"
+                tick={{ fontSize: 12 }}
+                interval="preserveStartEnd"
+              />
+              <YAxis
+                tickFormatter={(v: number) => {
+                  if (v >= 10000) return `${(v / 10000).toFixed(1)}억`;
+                  return `${v.toLocaleString()}`;
+                }}
+                tick={{ fontSize: 12 }}
+                width={70}
+              />
+              <Tooltip
+                formatter={(value: unknown, name: unknown) => {
+                  const v = Number(value);
+                  const n = String(name);
+                  if (n === "maxPrice") return [formatPrice(v), "최고가"];
+                  if (n === "avgPrice") return [formatPrice(v), "평균가"];
+                  if (n === "minPrice") return [formatPrice(v), "최저가"];
+                  return [formatPrice(v), n];
+                }}
+                labelFormatter={(label: unknown) => String(label)}
+              />
+              <Legend
+                formatter={(value: unknown) => {
+                  const v = String(value);
+                  if (v === "maxPrice") return "최고가";
+                  if (v === "avgPrice") return "평균가";
+                  if (v === "minPrice") return "최저가";
+                  return v;
+                }}
+              />
+              <Area
+                type="monotone"
+                dataKey="maxPrice"
+                stroke="hsl(0, 72%, 51%)"
+                fill="hsl(0, 72%, 51%)"
+                fillOpacity={0.1}
+                strokeWidth={1}
+              />
+              <Area
+                type="monotone"
+                dataKey="avgPrice"
+                stroke="hsl(221, 83%, 53%)"
+                fill="hsl(221, 83%, 53%)"
+                fillOpacity={0.2}
+                strokeWidth={2}
+              />
+              <Area
+                type="monotone"
+                dataKey="minPrice"
+                stroke="hsl(142, 71%, 45%)"
+                fill="hsl(142, 71%, 45%)"
+                fillOpacity={0.1}
+                strokeWidth={1}
+              />
+            </AreaChart>
+          )}
+        </ResponsiveContainer>
+      </div>
+
+      {/* Summary table below chart */}
+      <div className="overflow-x-auto rounded-lg border">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b bg-secondary/30 text-left">
+              <th className="px-3 py-2 font-medium">월</th>
+              <th className="px-3 py-2 text-right font-medium">평균가</th>
+              <th className="px-3 py-2 text-right font-medium">최저가</th>
+              <th className="px-3 py-2 text-right font-medium">최고가</th>
+              <th className="px-3 py-2 text-right font-medium">거래 건수</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((d) => (
+              <tr key={d.yearMonth} className="border-b hover:bg-secondary/10">
+                <td className="px-3 py-2">{formatYearMonth(d.yearMonth)}</td>
+                <td className="px-3 py-2 text-right font-medium text-primary">
+                  {formatPrice(d.avgPrice)}
+                </td>
+                <td className="px-3 py-2 text-right text-green-600">
+                  {formatPrice(d.minPrice)}
+                </td>
+                <td className="px-3 py-2 text-right text-red-600">
+                  {formatPrice(d.maxPrice)}
+                </td>
+                <td className="px-3 py-2 text-right">{d.tradeCount}건</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/real-price/page.tsx
+++ b/apps/web/src/app/real-price/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback } from "react";
 import {
   BarChart,
   Bar,
@@ -13,6 +13,7 @@ import {
   ScatterChart,
   Scatter,
 } from "recharts";
+import MonthlyPriceTrendChart from "./_components/MonthlyPriceTrendChart";
 
 const REGIONS = [
   { code: "11110", name: "서울 종로구" },
@@ -96,6 +97,16 @@ interface Trade {
   roadNm: string;
 }
 
+interface MonthlyPriceSummaryItem {
+  yearMonth: string;
+  avgPrice: number;
+  minPrice: number;
+  maxPrice: number;
+  tradeCount: number;
+}
+
+type ViewMode = "table" | "chart" | "trend";
+
 function getMonthOptions() {
   const options: { value: string; label: string }[] = [];
   const now = new Date();
@@ -115,7 +126,15 @@ export default function RealPricePage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [searched, setSearched] = useState(false);
-  const [viewMode, setViewMode] = useState<"table" | "chart">("table");
+  const [viewMode, setViewMode] = useState<ViewMode>("table");
+
+  // Trend-related state
+  const [trendFromMonth, setTrendFromMonth] = useState(() => getMonthOptions()[5].value);
+  const [trendToMonth, setTrendToMonth] = useState(() => getMonthOptions()[0].value);
+  const [trendData, setTrendData] = useState<MonthlyPriceSummaryItem[]>([]);
+  const [trendLoading, setTrendLoading] = useState(false);
+  const [trendError, setTrendError] = useState<string | null>(null);
+  const [trendSearched, setTrendSearched] = useState(false);
 
   const monthOptions = getMonthOptions();
 
@@ -180,6 +199,36 @@ export default function RealPricePage() {
     }
   }
 
+  const handleTrendSearch = useCallback(async () => {
+    if (trendFromMonth > trendToMonth) {
+      setTrendError("시작월이 종료월보다 이후입니다.");
+      return;
+    }
+    setTrendLoading(true);
+    setTrendError(null);
+    setTrendSearched(true);
+    try {
+      const res = await fetch(
+        `/api/real-price/trend?regionCode=${regionCode}&fromMonth=${trendFromMonth}&toMonth=${trendToMonth}`
+      );
+      const data = await res.json();
+
+      if (data.error) {
+        setTrendError(data.error);
+        setTrendData([]);
+        return;
+      }
+
+      const monthly: MonthlyPriceSummaryItem[] = data?.monthly ?? [];
+      setTrendData(monthly);
+    } catch {
+      setTrendError("추이 데이터를 불러오는 데 실패했습니다.");
+      setTrendData([]);
+    } finally {
+      setTrendLoading(false);
+    }
+  }, [regionCode, trendFromMonth, trendToMonth]);
+
   return (
     <div className="min-h-screen">
       <header className="border-b">
@@ -201,6 +250,31 @@ export default function RealPricePage() {
           국토교통부 아파트 매매 실거래가 데이터를 조회합니다.
         </p>
 
+        {/* View mode tabs */}
+        <div className="mb-4 flex gap-2">
+          {(["table", "chart", "trend"] as const).map((mode) => {
+            const labels: Record<ViewMode, string> = {
+              table: "테이블",
+              chart: "차트",
+              trend: "월별 추이",
+            };
+            return (
+              <button
+                key={mode}
+                onClick={() => setViewMode(mode)}
+                className={`rounded-lg px-4 py-1.5 text-sm font-medium transition-colors ${
+                  viewMode === mode
+                    ? "bg-primary text-primary-foreground"
+                    : "border hover:bg-accent"
+                }`}
+              >
+                {labels[mode]}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Search controls - single month for table/chart, date range for trend */}
         <div className="mb-8 flex flex-wrap items-end gap-4 rounded-lg border bg-card p-4">
           <div className="flex-1 min-w-[200px]">
             <label className="mb-1 block text-sm font-medium">지역</label>
@@ -216,169 +290,216 @@ export default function RealPricePage() {
               ))}
             </select>
           </div>
-          <div className="min-w-[160px]">
-            <label className="mb-1 block text-sm font-medium">계약월</label>
-            <select
-              value={dealYmd}
-              onChange={(e) => setDealYmd(e.target.value)}
-              className="w-full rounded-lg border bg-background px-3 py-2 text-sm"
-            >
-              {monthOptions.map((m) => (
-                <option key={m.value} value={m.value}>
-                  {m.label}
-                </option>
-              ))}
-            </select>
-          </div>
-          <button
-            onClick={handleSearch}
-            disabled={loading}
-            className="rounded-lg bg-primary px-6 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-          >
-            {loading ? "조회 중..." : "조회"}
-          </button>
+
+          {viewMode === "trend" ? (
+            <>
+              <div className="min-w-[160px]">
+                <label className="mb-1 block text-sm font-medium">시작월</label>
+                <select
+                  value={trendFromMonth}
+                  onChange={(e) => setTrendFromMonth(e.target.value)}
+                  className="w-full rounded-lg border bg-background px-3 py-2 text-sm"
+                >
+                  {monthOptions.map((m) => (
+                    <option key={m.value} value={m.value}>
+                      {m.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="min-w-[160px]">
+                <label className="mb-1 block text-sm font-medium">종료월</label>
+                <select
+                  value={trendToMonth}
+                  onChange={(e) => setTrendToMonth(e.target.value)}
+                  className="w-full rounded-lg border bg-background px-3 py-2 text-sm"
+                >
+                  {monthOptions.map((m) => (
+                    <option key={m.value} value={m.value}>
+                      {m.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <button
+                onClick={handleTrendSearch}
+                disabled={trendLoading}
+                className="rounded-lg bg-primary px-6 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              >
+                {trendLoading ? "조회 중..." : "추이 조회"}
+              </button>
+            </>
+          ) : (
+            <>
+              <div className="min-w-[160px]">
+                <label className="mb-1 block text-sm font-medium">계약월</label>
+                <select
+                  value={dealYmd}
+                  onChange={(e) => setDealYmd(e.target.value)}
+                  className="w-full rounded-lg border bg-background px-3 py-2 text-sm"
+                >
+                  {monthOptions.map((m) => (
+                    <option key={m.value} value={m.value}>
+                      {m.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <button
+                onClick={handleSearch}
+                disabled={loading}
+                className="rounded-lg bg-primary px-6 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              >
+                {loading ? "조회 중..." : "조회"}
+              </button>
+            </>
+          )}
         </div>
 
-        {loading && (
-          <div className="flex justify-center py-20">
-            <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-          </div>
-        )}
-
-        {error && (
-          <div className="rounded-lg border border-red-200 bg-red-50 p-6 text-center">
-            <p className="font-medium text-red-800">{error}</p>
-            <p className="mt-2 text-sm text-red-600">
-              data.go.kr API 키가 설정되어 있는지 확인해주세요.
-            </p>
-          </div>
-        )}
-
-        {!loading && !error && searched && trades.length === 0 && (
-          <div className="rounded-lg border p-6 text-center text-muted-foreground">
-            해당 조건의 거래 데이터가 없습니다.
-          </div>
-        )}
-
-        {!loading && trades.length > 0 && (
+        {/* Trend view */}
+        {viewMode === "trend" && (
           <>
-            <div className="mb-4 flex gap-2">
-              <button
-                onClick={() => setViewMode("table")}
-                className={`rounded-lg px-4 py-1.5 text-sm font-medium transition-colors ${
-                  viewMode === "table"
-                    ? "bg-primary text-primary-foreground"
-                    : "border hover:bg-accent"
-                }`}
-              >
-                테이블
-              </button>
-              <button
-                onClick={() => setViewMode("chart")}
-                className={`rounded-lg px-4 py-1.5 text-sm font-medium transition-colors ${
-                  viewMode === "chart"
-                    ? "bg-primary text-primary-foreground"
-                    : "border hover:bg-accent"
-                }`}
-              >
-                차트
-              </button>
-            </div>
+            {trendError && (
+              <div className="rounded-lg border border-red-200 bg-red-50 p-6 text-center">
+                <p className="font-medium text-red-800">{trendError}</p>
+                <p className="mt-2 text-sm text-red-600">
+                  data.go.kr API 키가 설정되어 있는지 확인해주세요.
+                </p>
+              </div>
+            )}
+            {!trendError && !trendSearched && !trendLoading && (
+              <div className="rounded-lg border p-6 text-center text-muted-foreground">
+                지역과 기간을 선택한 후 &quot;추이 조회&quot; 버튼을 눌러주세요.
+              </div>
+            )}
+            {(trendSearched || trendLoading) && (
+              <MonthlyPriceTrendChart data={trendData} loading={trendLoading} />
+            )}
+          </>
+        )}
 
-            {viewMode === "chart" && (
-              <div className="space-y-8">
-                {/* 법정동별 평균 가격 */}
-                {avgByDong.length > 0 && (
-                  <div className="rounded-lg border bg-card p-4">
-                    <h3 className="mb-4 text-sm font-semibold">법정동별 평균 거래가격 (만원)</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                      <BarChart data={avgByDong} layout="vertical" margin={{ left: 60 }}>
-                        <CartesianGrid strokeDasharray="3 3" />
-                        <XAxis type="number" tickFormatter={(v: number) => `${(v / 10000).toFixed(1)}억`} />
-                        <YAxis type="category" dataKey="name" width={80} tick={{ fontSize: 12 }} />
-                        <Tooltip
-                          formatter={(value: unknown) => [`${Number(value).toLocaleString()}만원`, "평균가"]}
-                          labelFormatter={(label: unknown) => String(label)}
-                        />
-                        <Bar dataKey="avg" fill="hsl(221, 83%, 53%)" radius={[0, 4, 4, 0]} />
-                      </BarChart>
-                    </ResponsiveContainer>
-                  </div>
-                )}
-
-                {/* 면적 vs 가격 산점도 */}
-                {areaVsPrice.length > 0 && (
-                  <div className="rounded-lg border bg-card p-4">
-                    <h3 className="mb-4 text-sm font-semibold">전용면적별 거래가격 분포</h3>
-                    <ResponsiveContainer width="100%" height={300}>
-                      <ScatterChart margin={{ bottom: 20 }}>
-                        <CartesianGrid strokeDasharray="3 3" />
-                        <XAxis
-                          type="number"
-                          dataKey="area"
-                          name="면적"
-                          unit="m²"
-                          tick={{ fontSize: 12 }}
-                        />
-                        <YAxis
-                          type="number"
-                          dataKey="price"
-                          name="가격"
-                          tickFormatter={(v: number) => `${(v / 10000).toFixed(1)}억`}
-                          tick={{ fontSize: 12 }}
-                        />
-                        <Tooltip
-                          formatter={(value: unknown, name: unknown) => {
-                            const v = Number(value);
-                            const n = String(name);
-                            if (n === "가격") return [`${v.toLocaleString()}만원`, n];
-                            return [`${v}m²`, n];
-                          }}
-                        />
-                        <Scatter data={areaVsPrice} fill="hsl(221, 83%, 53%)" fillOpacity={0.6} />
-                      </ScatterChart>
-                    </ResponsiveContainer>
-                  </div>
-                )}
+        {/* Single month views (table / chart) */}
+        {viewMode !== "trend" && (
+          <>
+            {loading && (
+              <div className="flex justify-center py-20">
+                <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
               </div>
             )}
 
-            {viewMode === "table" && (
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b bg-secondary/30 text-left">
-                  <th className="px-3 py-3 font-medium">아파트</th>
-                  <th className="px-3 py-3 font-medium">법정동</th>
-                  <th className="px-3 py-3 font-medium text-right">거래금액</th>
-                  <th className="px-3 py-3 font-medium text-right">전용면적</th>
-                  <th className="px-3 py-3 font-medium text-right">층</th>
-                  <th className="px-3 py-3 font-medium text-right">건축년도</th>
-                  <th className="px-3 py-3 font-medium">거래일</th>
-                </tr>
-              </thead>
-              <tbody>
-                {trades.map((t, i) => (
-                  <tr key={i} className="border-b hover:bg-secondary/10">
-                    <td className="px-3 py-3 font-medium">{t.aptNm}</td>
-                    <td className="px-3 py-3 text-muted-foreground">{t.umdNm}</td>
-                    <td className="px-3 py-3 text-right font-medium text-primary">
-                      {t.dealAmount?.trim()}만원
-                    </td>
-                    <td className="px-3 py-3 text-right">{t.excluUseAr}m²</td>
-                    <td className="px-3 py-3 text-right">{t.floor}층</td>
-                    <td className="px-3 py-3 text-right">{t.buildYear}</td>
-                    <td className="px-3 py-3 text-muted-foreground">
-                      {t.dealYear}.{t.dealMonth}.{t.dealDay}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-            <p className="mt-4 text-xs text-muted-foreground">
-              총 {trades.length}건 (최대 50건 표시)
-            </p>
-          </div>
+            {error && (
+              <div className="rounded-lg border border-red-200 bg-red-50 p-6 text-center">
+                <p className="font-medium text-red-800">{error}</p>
+                <p className="mt-2 text-sm text-red-600">
+                  data.go.kr API 키가 설정되어 있는지 확인해주세요.
+                </p>
+              </div>
+            )}
+
+            {!loading && !error && searched && trades.length === 0 && (
+              <div className="rounded-lg border p-6 text-center text-muted-foreground">
+                해당 조건의 거래 데이터가 없습니다.
+              </div>
+            )}
+
+            {!loading && trades.length > 0 && (
+              <>
+                {viewMode === "chart" && (
+                  <div className="space-y-8">
+                    {/* 법정동별 평균 가격 */}
+                    {avgByDong.length > 0 && (
+                      <div className="rounded-lg border bg-card p-4">
+                        <h3 className="mb-4 text-sm font-semibold">법정동별 평균 거래가격 (만원)</h3>
+                        <ResponsiveContainer width="100%" height={300}>
+                          <BarChart data={avgByDong} layout="vertical" margin={{ left: 60 }}>
+                            <CartesianGrid strokeDasharray="3 3" />
+                            <XAxis type="number" tickFormatter={(v: number) => `${(v / 10000).toFixed(1)}억`} />
+                            <YAxis type="category" dataKey="name" width={80} tick={{ fontSize: 12 }} />
+                            <Tooltip
+                              formatter={(value: unknown) => [`${Number(value).toLocaleString()}만원`, "평균가"]}
+                              labelFormatter={(label: unknown) => String(label)}
+                            />
+                            <Bar dataKey="avg" fill="hsl(221, 83%, 53%)" radius={[0, 4, 4, 0]} />
+                          </BarChart>
+                        </ResponsiveContainer>
+                      </div>
+                    )}
+
+                    {/* 면적 vs 가격 산점도 */}
+                    {areaVsPrice.length > 0 && (
+                      <div className="rounded-lg border bg-card p-4">
+                        <h3 className="mb-4 text-sm font-semibold">전용면적별 거래가격 분포</h3>
+                        <ResponsiveContainer width="100%" height={300}>
+                          <ScatterChart margin={{ bottom: 20 }}>
+                            <CartesianGrid strokeDasharray="3 3" />
+                            <XAxis
+                              type="number"
+                              dataKey="area"
+                              name="면적"
+                              unit="m²"
+                              tick={{ fontSize: 12 }}
+                            />
+                            <YAxis
+                              type="number"
+                              dataKey="price"
+                              name="가격"
+                              tickFormatter={(v: number) => `${(v / 10000).toFixed(1)}억`}
+                              tick={{ fontSize: 12 }}
+                            />
+                            <Tooltip
+                              formatter={(value: unknown, name: unknown) => {
+                                const v = Number(value);
+                                const n = String(name);
+                                if (n === "가격") return [`${v.toLocaleString()}만원`, n];
+                                return [`${v}m²`, n];
+                              }}
+                            />
+                            <Scatter data={areaVsPrice} fill="hsl(221, 83%, 53%)" fillOpacity={0.6} />
+                          </ScatterChart>
+                        </ResponsiveContainer>
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {viewMode === "table" && (
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="border-b bg-secondary/30 text-left">
+                          <th className="px-3 py-3 font-medium">아파트</th>
+                          <th className="px-3 py-3 font-medium">법정동</th>
+                          <th className="px-3 py-3 font-medium text-right">거래금액</th>
+                          <th className="px-3 py-3 font-medium text-right">전용면적</th>
+                          <th className="px-3 py-3 font-medium text-right">층</th>
+                          <th className="px-3 py-3 font-medium text-right">건축년도</th>
+                          <th className="px-3 py-3 font-medium">거래일</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {trades.map((t, i) => (
+                          <tr key={i} className="border-b hover:bg-secondary/10">
+                            <td className="px-3 py-3 font-medium">{t.aptNm}</td>
+                            <td className="px-3 py-3 text-muted-foreground">{t.umdNm}</td>
+                            <td className="px-3 py-3 text-right font-medium text-primary">
+                              {t.dealAmount?.trim()}만원
+                            </td>
+                            <td className="px-3 py-3 text-right">{t.excluUseAr}m²</td>
+                            <td className="px-3 py-3 text-right">{t.floor}층</td>
+                            <td className="px-3 py-3 text-right">{t.buildYear}</td>
+                            <td className="px-3 py-3 text-muted-foreground">
+                              {t.dealYear}.{t.dealMonth}.{t.dealDay}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                    <p className="mt-4 text-xs text-muted-foreground">
+                      총 {trades.length}건 (최대 50건 표시)
+                    </p>
+                  </div>
+                )}
+              </>
             )}
           </>
         )}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -117,6 +117,21 @@ export interface RealPriceResponse {
   yearMonth: string;
 }
 
+export interface MonthlyPriceSummary {
+  yearMonth: string;
+  avgPrice: number;
+  minPrice: number;
+  maxPrice: number;
+  tradeCount: number;
+}
+
+export interface RealPriceTrendResponse {
+  regionCode: string;
+  fromMonth: string;
+  toMonth: string;
+  monthly: MonthlyPriceSummary[];
+}
+
 // 부동산 용어
 export interface GlossaryTerm {
   term: string;


### PR DESCRIPTION
## Summary
- MonthlyPriceTrendChart 컴포넌트 (LineChart + AreaChart 모드)
- 3탭 UI: 테이블 / 차트 / 월별 추이
- Next.js API route proxy → NestJS /real-price/trend 엔드포인트
- 시작/종료 월 선택기로 기간별 추이 조회

Closes #20

https://claude.ai/code/session_01Hfi6bb581xcUz4Zpf8r5iE