### PR TITLE
[Task 2.3] Naver OAuth 로그인 구현

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -29,6 +29,7 @@
     "passport-google-oauth20": "^2.0.0",
     "passport-jwt": "^4.0.1",
     "passport-kakao": "^1.0.1",
+    "passport-naver-v2": "^2.0.8",
     "pg": "^8.13.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.0",

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -14,6 +14,7 @@ import { z } from "zod";
 import { AuthService } from "./auth.service";
 import { GoogleAuthGuard } from "./google-auth.guard";
 import { KakaoAuthGuard } from "./kakao-auth.guard";
+import { NaverAuthGuard } from "./naver-auth.guard";
 import { JwtAuthGuard } from "./jwt-auth.guard";
 import { Public } from "./public.decorator";
 
@@ -90,7 +91,33 @@ export class AuthController {
     const frontendUrl =
       this.configService.get<string>("FRONTEND_URL") || "http://localhost:3000";
 
-    // 프론트엔드로 토큰을 쿼리 파라미터로 전달
+    const redirectUrl = new URL("/auth/callback", frontendUrl);
+    redirectUrl.searchParams.set("accessToken", tokens.accessToken);
+    redirectUrl.searchParams.set("refreshToken", tokens.refreshToken);
+
+    res.redirect(redirectUrl.toString());
+  }
+
+  /** Naver OAuth 로그인 시작 */
+  @Public()
+  @UseGuards(NaverAuthGuard)
+  @Get("naver")
+  naverLogin(): void {
+    // NaverAuthGuard가 Naver OAuth 페이지로 리다이렉트
+  }
+
+  /** Naver OAuth 콜백 */
+  @Public()
+  @UseGuards(NaverAuthGuard)
+  @Get("naver/callback")
+  async naverCallback(
+    @Request() req: { user: OAuthUser },
+    @Res() res: Response,
+  ): Promise<void> {
+    const tokens = await this.authService.validateOAuthLogin(req.user);
+    const frontendUrl =
+      this.configService.get<string>("FRONTEND_URL") || "http://localhost:3000";
+
     const redirectUrl = new URL("/auth/callback", frontendUrl);
     redirectUrl.searchParams.set("accessToken", tokens.accessToken);
     redirectUrl.searchParams.set("refreshToken", tokens.refreshToken);

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -8,6 +8,7 @@ import { AuthController } from "./auth.controller";
 import { AuthService } from "./auth.service";
 import { GoogleStrategy } from "./google.strategy";
 import { KakaoStrategy } from "./kakao.strategy";
+import { NaverStrategy } from "./naver.strategy";
 import { JwtStrategy } from "./jwt.strategy";
 
 @Module({
@@ -25,7 +26,7 @@ import { JwtStrategy } from "./jwt.strategy";
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy, GoogleStrategy, KakaoStrategy],
+  providers: [AuthService, JwtStrategy, GoogleStrategy, KakaoStrategy, NaverStrategy],
   exports: [AuthService, JwtModule],
 })
 export class AuthModule {}

--- a/apps/api/src/auth/naver-auth.guard.ts
+++ b/apps/api/src/auth/naver-auth.guard.ts
@@ -1,0 +1,9 @@
+import { Injectable, ExecutionContext } from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+
+@Injectable()
+export class NaverAuthGuard extends AuthGuard("naver") {
+  canActivate(context: ExecutionContext) {
+    return super.canActivate(context);
+  }
+}

--- a/apps/api/src/auth/naver.strategy.ts
+++ b/apps/api/src/auth/naver.strategy.ts
@@ -1,0 +1,40 @@
+import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { PassportStrategy } from "@nestjs/passport";
+import { Strategy, Profile } from "passport-naver-v2";
+
+type VerifyCallback = (error: Error | null, user?: NaverOAuthUser | false) => void;
+
+interface NaverOAuthUser {
+  provider: string;
+  providerId: string;
+  email: string | null;
+  nickname: string | null;
+}
+
+@Injectable()
+export class NaverStrategy extends PassportStrategy(Strategy, "naver") {
+  constructor(config: ConfigService) {
+    super({
+      clientID: config.get<string>("NAVER_CLIENT_ID") || "",
+      clientSecret: config.get<string>("NAVER_CLIENT_SECRET") || "",
+      callbackURL: config.get<string>("NAVER_CALLBACK_URL") || "http://localhost:4000/auth/naver/callback",
+    });
+  }
+
+  validate(
+    _accessToken: string,
+    _refreshToken: string,
+    profile: Profile,
+    done: VerifyCallback,
+  ): void {
+    const user: NaverOAuthUser = {
+      provider: "naver",
+      providerId: profile.id,
+      email: profile.email ?? null,
+      nickname: profile.nickname ?? null,
+    };
+
+    done(null, user);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
         "passport-jwt": "^4.0.1",
-        "passport-kakao": "^1.0.1",
+        "passport-naver-v2": "^2.0.8",
         "pg": "^8.13.0",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.0",
@@ -46,7 +46,6 @@
         "@types/express": "^4.17.0",
         "@types/jest": "^30.0.0",
         "@types/passport-jwt": "^4.0.1",
-        "@types/passport-kakao": "^1.0.3",
         "@zipath/config": "*",
         "jest": "^30.3.0",
         "ts-jest": "^29.4.6",
@@ -2777,17 +2776,6 @@
       "dependencies": {
         "@types/jsonwebtoken": "*",
         "@types/passport-strategy": "*"
-      }
-    },
-    "node_modules/@types/passport-kakao": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/passport-kakao/-/passport-kakao-1.0.3.tgz",
-      "integrity": "sha512-McK5kpeiOptvjIPkiA/QS3k82//z5JM7Y3yBLMDvEA0QMMhFMcWUHhyebL1Qy+0i0n8jS+Oe4U6xAvkU22SXXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "*",
-        "@types/passport": "*"
       }
     },
     "node_modules/@types/passport-oauth2": {
@@ -8038,33 +8026,13 @@
         "passport-strategy": "^1.0.0"
       }
     },
-    "node_modules/passport-kakao": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/passport-kakao/-/passport-kakao-1.0.1.tgz",
-      "integrity": "sha512-uItaYRVrTHL6iGPMnMZvPa/O1GrAdh/V6EMjOHcFlQcVroZ9wgG7BZ5PonMNJCxfHQ3L2QVNRnzhKWUzSsumbw==",
+    "node_modules/passport-naver-v2": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/passport-naver-v2/-/passport-naver-v2-2.0.8.tgz",
+      "integrity": "sha512-CA0u+aA4K4Zf5e3dSd47agOS69ULOdBGei7CZY2BN1cEbLnhnc6OalFPvnXLuEKT8I4IuGwvh3EBZCST2FoI+A==",
       "license": "MIT",
       "dependencies": {
-        "passport-oauth2": "~1.1.2",
-        "pkginfo": "~0.3.0"
-      }
-    },
-    "node_modules/passport-kakao/node_modules/oauth": {
-      "version": "0.9.15",
-      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
-      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
-      "license": "MIT"
-    },
-    "node_modules/passport-kakao/node_modules/passport-oauth2": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.1.2.tgz",
-      "integrity": "sha512-wpsGtJDHHQUjyc9WcV9FFB0bphFExpmKtzkQrxpH1vnSr6RcWa3ZEGHx/zGKAh2PN7Po9TKYB1fJeOiIBspNPA==",
-      "dependencies": {
-        "oauth": "0.9.x",
-        "passport-strategy": "1.x.x",
-        "uid2": "0.0.x"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
+        "passport-oauth2": "^1.5.0"
       }
     },
     "node_modules/passport-oauth2": {
@@ -8307,15 +8275,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/pkginfo": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
-      "integrity": "sha512-yO5feByMzAp96LtP58wvPKSbaKAi/1C4kV9XpTctr6EepnP6F33RBNOiVrdz9BrPA98U2BMFsTNHo44TWcbQ2A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/pluralize": {


### PR DESCRIPTION
## Summary
- Naver Passport Strategy + NaverAuthGuard 구현
- GET /auth/naver, GET /auth/naver/callback 엔드포인트
- passport-naver-v2 패키지 추가

Closes #18

https://claude.ai/code/session_01Hfi6bb581xcUz4Zpf8r5iE