### PR TITLE
[Task 2.4] 유저 프로필 페이지 구현

### DIFF
--- a/apps/web/src/app/api/auth/profile/route.ts
+++ b/apps/web/src/app/api/auth/profile/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000/api";
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get("Authorization");
+
+  if (!authHeader) {
+    return NextResponse.json(
+      { error: "Authorization header is required" },
+      { status: 401 },
+    );
+  }
+
+  try {
+    const res = await fetch(`${API_BASE}/auth/profile`, {
+      headers: {
+        Authorization: authHeader,
+      },
+    });
+
+    if (!res.ok) {
+      const body: unknown = await res.json().catch(() => null);
+      return NextResponse.json(
+        {
+          error:
+            (body as Record<string, string>)?.message ??
+            `Backend error: ${res.status}`,
+        },
+        { status: res.status },
+      );
+    }
+
+    const data: unknown = await res.json();
+    return NextResponse.json(data);
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to fetch profile" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/auth/callback/page.tsx
+++ b/apps/web/src/app/auth/callback/page.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
+
+export default function AuthCallbackPage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const { login } = useAuth();
+
+  useEffect(() => {
+    const accessToken = searchParams.get("accessToken");
+    const refreshToken = searchParams.get("refreshToken");
+
+    if (accessToken && refreshToken) {
+      login(accessToken, refreshToken);
+      router.replace("/profile");
+    } else {
+      // No tokens, redirect to login
+      router.replace("/login");
+    }
+  }, [searchParams, login, router]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <p className="text-muted-foreground">로그인 처리 중...</p>
+    </div>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Providers } from "./providers";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -13,7 +14,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ko">
-      <body className="min-h-screen antialiased">{children}</body>
+      <body className="min-h-screen antialiased">
+        <Providers>{children}</Providers>
+      </body>
     </html>
   );
 }

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useAuth } from "@/contexts/AuthContext";
+
+type ProviderLabel = "google" | "kakao" | "naver";
+
+const PROVIDER_LABELS: Record<ProviderLabel, string> = {
+  google: "Google",
+  kakao: "카카오",
+  naver: "네이버",
+};
+
+function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+function formatDateTime(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function getProviderLabel(provider: string | null): string {
+  if (!provider) return "알 수 없음";
+  return PROVIDER_LABELS[provider as ProviderLabel] ?? provider;
+}
+
+export default function ProfilePage() {
+  const { user, isLoading, isAuthenticated, logout } = useAuth();
+  const router = useRouter();
+
+  function handleLogout() {
+    logout();
+    router.push("/");
+  }
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen">
+        <header className="border-b">
+          <div className="mx-auto flex h-16 max-w-5xl items-center justify-between px-4">
+            <Link href="/" className="text-xl font-bold text-primary">
+              Zipath
+            </Link>
+          </div>
+        </header>
+        <main className="mx-auto flex max-w-md flex-col items-center px-4 py-20">
+          <p className="text-muted-foreground">로딩 중...</p>
+        </main>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated || !user) {
+    return (
+      <div className="min-h-screen">
+        <header className="border-b">
+          <div className="mx-auto flex h-16 max-w-5xl items-center justify-between px-4">
+            <Link href="/" className="text-xl font-bold text-primary">
+              Zipath
+            </Link>
+          </div>
+        </header>
+        <main className="mx-auto flex max-w-md flex-col items-center px-4 py-20">
+          <h1 className="mb-4 text-2xl font-bold">로그인이 필요합니다</h1>
+          <p className="mb-6 text-sm text-muted-foreground">
+            프로필을 보려면 먼저 로그인해주세요.
+          </p>
+          <Link
+            href="/login"
+            className="rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            로그인하기
+          </Link>
+        </main>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen">
+      <header className="border-b">
+        <div className="mx-auto flex h-16 max-w-5xl items-center justify-between px-4">
+          <Link href="/" className="text-xl font-bold text-primary">
+            Zipath
+          </Link>
+          <nav className="flex items-center gap-4 text-sm">
+            <Link
+              href="/"
+              className="text-muted-foreground hover:text-foreground"
+            >
+              홈
+            </Link>
+            <button
+              onClick={handleLogout}
+              className="text-muted-foreground hover:text-foreground"
+            >
+              로그아웃
+            </button>
+          </nav>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-lg px-4 py-12">
+        <h1 className="mb-8 text-2xl font-bold">내 프로필</h1>
+
+        <div className="rounded-lg border bg-card p-6">
+          {/* Profile avatar placeholder */}
+          <div className="mb-6 flex items-center gap-4">
+            <div className="flex h-14 w-14 items-center justify-center rounded-full bg-primary/10 text-xl font-bold text-primary">
+              {user.nickname?.charAt(0) ?? user.email?.charAt(0) ?? "?"}
+            </div>
+            <div>
+              <p className="font-semibold">
+                {user.nickname ?? "닉네임 없음"}
+              </p>
+              <p className="text-sm text-muted-foreground">
+                {user.email ?? "이메일 없음"}
+              </p>
+            </div>
+          </div>
+
+          <hr className="mb-6" />
+
+          {/* Profile details */}
+          <dl className="space-y-4">
+            <div className="flex justify-between">
+              <dt className="text-sm text-muted-foreground">이메일</dt>
+              <dd className="text-sm font-medium">
+                {user.email ?? "등록되지 않음"}
+              </dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-sm text-muted-foreground">닉네임</dt>
+              <dd className="text-sm font-medium">
+                {user.nickname ?? "등록되지 않음"}
+              </dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-sm text-muted-foreground">로그인 방식</dt>
+              <dd className="text-sm font-medium">
+                {getProviderLabel(user.provider)}
+              </dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-sm text-muted-foreground">가입일</dt>
+              <dd className="text-sm font-medium">
+                {formatDate(user.createdAt)}
+              </dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-sm text-muted-foreground">마지막 활동</dt>
+              <dd className="text-sm font-medium">
+                {formatDateTime(user.lastActiveAt)}
+              </dd>
+            </div>
+          </dl>
+        </div>
+
+        {/* Actions */}
+        <div className="mt-6 flex flex-col gap-3">
+          <Link
+            href="/"
+            className="rounded-lg border px-4 py-3 text-center text-sm font-medium hover:bg-accent"
+          >
+            홈으로 돌아가기
+          </Link>
+          <button
+            onClick={handleLogout}
+            className="rounded-lg bg-red-50 px-4 py-3 text-sm font-medium text-red-600 hover:bg-red-100"
+          >
+            로그아웃
+          </button>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { AuthProvider } from "@/contexts/AuthContext";
+
+export function Providers({ children }: { children: ReactNode }) {
+  return <AuthProvider>{children}</AuthProvider>;
+}

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useCallback,
+  type ReactNode,
+} from "react";
+
+interface UserProfile {
+  id: number;
+  email: string | null;
+  nickname: string | null;
+  provider: string | null;
+  createdAt: string;
+  lastActiveAt: string;
+}
+
+interface AuthContextValue {
+  user: UserProfile | null;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  login: (accessToken: string, refreshToken: string) => void;
+  logout: () => void;
+  fetchProfile: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+function getStoredToken(key: string): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(key);
+}
+
+function setStoredToken(key: string, value: string): void {
+  localStorage.setItem(key, value);
+}
+
+function removeStoredToken(key: string): void {
+  localStorage.removeItem(key);
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<UserProfile | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchProfile = useCallback(async () => {
+    const accessToken = getStoredToken("accessToken");
+    if (!accessToken) {
+      setUser(null);
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const res = await fetch("/api/auth/profile", {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      if (!res.ok) {
+        // Token expired or invalid
+        removeStoredToken("accessToken");
+        removeStoredToken("refreshToken");
+        setUser(null);
+        return;
+      }
+
+      const data: unknown = await res.json();
+      setUser(data as UserProfile);
+    } catch {
+      setUser(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const login = useCallback(
+    (accessToken: string, refreshToken: string) => {
+      setStoredToken("accessToken", accessToken);
+      setStoredToken("refreshToken", refreshToken);
+      void fetchProfile();
+    },
+    [fetchProfile],
+  );
+
+  const logout = useCallback(() => {
+    removeStoredToken("accessToken");
+    removeStoredToken("refreshToken");
+    setUser(null);
+  }, []);
+
+  useEffect(() => {
+    void fetchProfile();
+  }, [fetchProfile]);
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        isLoading,
+        isAuthenticated: user !== null,
+        login,
+        logout,
+        fetchProfile,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- AuthContext + AuthProvider (localStorage 토큰 관리, 자동 프로필 조회)
- 프로필 페이지 (/profile): 유저 정보 표시, 로그아웃
- OAuth 콜백 페이지 (/auth/callback): 토큰 수신 → 로그인 → 리다이렉트
- API route proxy: /api/auth/profile
- layout.tsx에 Providers 래퍼 추가

Closes #19

https://claude.ai/code/session_01Hfi6bb581xcUz4Zpf8r5iE