### PR TITLE
fix: resolve web and API build errors

### DIFF
--- a/apps/api/src/common/http-exception.filter.ts
+++ b/apps/api/src/common/http-exception.filter.ts
@@ -144,7 +144,7 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       exception.stack,
     );
 
-    const driverError = exception.driverError as Record<string, unknown> | undefined;
+    const driverError = exception.driverError as unknown as Record<string, unknown> | undefined;
     const pgCode = driverError?.code as string | undefined;
 
     // PostgreSQL unique violation

--- a/apps/api/src/contract-analysis/contract-analysis.service.ts
+++ b/apps/api/src/contract-analysis/contract-analysis.service.ts
@@ -11,7 +11,7 @@ interface ChecklistItem {
   tip?: string;
 }
 
-interface ContractChecklist {
+export interface ContractChecklist {
   contractType: string;
   title: string;
   description: string;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "react-hook-form": "^7.50.0",
+    "react-is": "^19.2.4",
     "recharts": "^3.8.0",
     "tailwind-merge": "^2.2.0",
     "zod": "^3.22.0"

--- a/apps/web/src/app/auth/callback/page.tsx
+++ b/apps/web/src/app/auth/callback/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect } from "react";
+import { Suspense, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 
-export default function AuthCallbackPage() {
+function AuthCallbackContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const { login } = useAuth();
@@ -17,7 +17,6 @@ export default function AuthCallbackPage() {
       login(accessToken, refreshToken);
       router.replace("/profile");
     } else {
-      // No tokens, redirect to login
       router.replace("/login");
     }
   }, [searchParams, login, router]);
@@ -26,5 +25,19 @@ export default function AuthCallbackPage() {
     <div className="flex min-h-screen items-center justify-center">
       <p className="text-muted-foreground">로그인 처리 중...</p>
     </div>
+  );
+}
+
+export default function AuthCallbackPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center">
+          <p className="text-muted-foreground">로그인 처리 중...</p>
+        </div>
+      }
+    >
+      <AuthCallbackContent />
+    </Suspense>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
         "passport-jwt": "^4.0.1",
+        "passport-kakao": "^1.0.1",
         "passport-naver-v2": "^2.0.8",
         "pg": "^8.13.0",
         "reflect-metadata": "^0.2.0",
@@ -46,6 +47,7 @@
         "@types/express": "^4.17.0",
         "@types/jest": "^30.0.0",
         "@types/passport-jwt": "^4.0.1",
+        "@types/passport-kakao": "^1.0.3",
         "@zipath/config": "*",
         "jest": "^30.3.0",
         "ts-jest": "^29.4.6",
@@ -289,6 +291,7 @@
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
         "react-hook-form": "^7.50.0",
+        "react-is": "^19.2.4",
         "recharts": "^3.8.0",
         "tailwind-merge": "^2.2.0",
         "zod": "^3.22.0"
@@ -2776,6 +2779,17 @@
       "dependencies": {
         "@types/jsonwebtoken": "*",
         "@types/passport-strategy": "*"
+      }
+    },
+    "node_modules/@types/passport-kakao": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/passport-kakao/-/passport-kakao-1.0.3.tgz",
+      "integrity": "sha512-McK5kpeiOptvjIPkiA/QS3k82//z5JM7Y3yBLMDvEA0QMMhFMcWUHhyebL1Qy+0i0n8jS+Oe4U6xAvkU22SXXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/passport": "*"
       }
     },
     "node_modules/@types/passport-oauth2": {
@@ -8026,6 +8040,35 @@
         "passport-strategy": "^1.0.0"
       }
     },
+    "node_modules/passport-kakao": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/passport-kakao/-/passport-kakao-1.0.1.tgz",
+      "integrity": "sha512-uItaYRVrTHL6iGPMnMZvPa/O1GrAdh/V6EMjOHcFlQcVroZ9wgG7BZ5PonMNJCxfHQ3L2QVNRnzhKWUzSsumbw==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-oauth2": "~1.1.2",
+        "pkginfo": "~0.3.0"
+      }
+    },
+    "node_modules/passport-kakao/node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
+      "license": "MIT"
+    },
+    "node_modules/passport-kakao/node_modules/passport-oauth2": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.1.2.tgz",
+      "integrity": "sha512-wpsGtJDHHQUjyc9WcV9FFB0bphFExpmKtzkQrxpH1vnSr6RcWa3ZEGHx/zGKAh2PN7Po9TKYB1fJeOiIBspNPA==",
+      "dependencies": {
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/passport-naver-v2": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/passport-naver-v2/-/passport-naver-v2-2.0.8.tgz",
@@ -8275,6 +8318,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pkginfo": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+      "integrity": "sha512-yO5feByMzAp96LtP58wvPKSbaKAi/1C4kV9XpTctr6EepnP6F33RBNOiVrdz9BrPA98U2BMFsTNHo44TWcbQ2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/pluralize": {
@@ -8673,6 +8725,12 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
+    },
+    "node_modules/react-is": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",


### PR DESCRIPTION
## Summary
- **Web**: Install `react-is` (peer dep of `recharts`), wrap auth callback in `Suspense`
- **API**: Install passport packages, fix `driverError` type cast, export `ContractChecklist` interface

## Test plan
- [x] `npx tsc --noEmit` passes in `apps/api`
- [x] `npx next build` succeeds in `apps/web`

https://claude.ai/code/session_01Hfi6bb581xcUz4Zpf8r5iE