### PR TITLE
feat(api): #74 실거래가·청약 공고 변동 감지 스케줄러 구현

### DIFF
--- a/apps/api/src/notification/notification-scheduler.service.spec.ts
+++ b/apps/api/src/notification/notification-scheduler.service.spec.ts
@@ -111,7 +111,7 @@ describe("NotificationSchedulerService", () => {
         avgPrice: 100000,
         tradeCount: 1,
       });
-      notificationRepo.findOne!.mockResolvedValue(null);
+      notificationRepo.findBy!.mockResolvedValue([]);
 
       await service.detectPriceChanges();
 
@@ -127,7 +127,6 @@ describe("NotificationSchedulerService", () => {
       expect(saved.referenceId).toMatch(/^11680:\d{6}$/);
       expect(saved.message).toContain("참고용이며 법적 효력이 없습니다");
 
-      // baseline 갱신 호출 — 평균가가 105000 으로 업데이트되어야 함
       expect(baselineRepo.save).toHaveBeenCalledTimes(1);
       const updatedBaseline = baselineRepo.save!.mock.calls[0][0] as {
         avgPrice: number;
@@ -150,16 +149,12 @@ describe("NotificationSchedulerService", () => {
         avgPrice: 100000,
         tradeCount: 1,
       });
-      notificationRepo.findOne!.mockResolvedValue({
-        id: 99,
-        userId: 10,
-        type: "PRICE_CHANGE",
-        referenceId: "11680:202505",
-      });
+      notificationRepo.findBy!.mockResolvedValue([
+        { id: 99, userId: 10, type: "PRICE_CHANGE", referenceId: "11680:202505" },
+      ]);
 
       await service.detectPriceChanges();
 
-      // 중복이므로 notification 생성 안 함. baseline 갱신은 수행.
       expect(notificationRepo.save).not.toHaveBeenCalled();
       expect(baselineRepo.save).toHaveBeenCalledTimes(1);
     });
@@ -167,8 +162,6 @@ describe("NotificationSchedulerService", () => {
 
   describe("detectNewAnnouncements", () => {
     it("lastAnnouncementCheckAt 이 null 인 첫 실행은 시각만 기록한다", async () => {
-      service.resetAnnouncementCheckpoint();
-
       await service.detectNewAnnouncements();
 
       expect(announcementRepo.findBy).not.toHaveBeenCalled();
@@ -176,11 +169,8 @@ describe("NotificationSchedulerService", () => {
     });
 
     it("관심 지역 매칭 공고가 있으면 사용자에게 알림을 생성한다", async () => {
-      // 1차 호출 — 첫 실행: 시각만 기록
-      service.resetAnnouncementCheckpoint();
       await service.detectNewAnnouncements();
 
-      // 2차 호출 준비 — 신규 공고 1건
       announcementRepo.findBy!.mockResolvedValue([
         {
           id: 42,
@@ -198,7 +188,7 @@ describe("NotificationSchedulerService", () => {
           isActive: true,
         },
       ]);
-      notificationRepo.findOne!.mockResolvedValue(null);
+      notificationRepo.findBy!.mockResolvedValue([]);
 
       await service.detectNewAnnouncements();
 

--- a/apps/api/src/notification/notification-scheduler.service.spec.ts
+++ b/apps/api/src/notification/notification-scheduler.service.spec.ts
@@ -1,0 +1,238 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { getRepositoryToken } from "@nestjs/typeorm";
+import { ObjectLiteral, Repository } from "typeorm";
+import {
+  Announcement,
+  Notification,
+  NotificationPreference,
+  PriceBaseline,
+} from "@zipath/db";
+import { NotificationSchedulerService } from "./notification-scheduler.service";
+import { RealPriceService } from "../real-price/real-price.service";
+
+type MockRepository<T extends ObjectLiteral = ObjectLiteral> = Partial<
+  Record<keyof Repository<T>, jest.Mock>
+>;
+
+const createMockRepository = <
+  T extends ObjectLiteral = ObjectLiteral,
+>(): MockRepository<T> => ({
+  find: jest.fn(),
+  findBy: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn((entity) => entity),
+  save: jest.fn((entity) => Promise.resolve(entity)),
+});
+
+describe("NotificationSchedulerService", () => {
+  let service: NotificationSchedulerService;
+  let preferenceRepo: MockRepository<NotificationPreference>;
+  let notificationRepo: MockRepository<Notification>;
+  let baselineRepo: MockRepository<PriceBaseline>;
+  let announcementRepo: MockRepository<Announcement>;
+  let realPriceService: { search: jest.Mock };
+
+  beforeEach(async () => {
+    realPriceService = { search: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationSchedulerService,
+        {
+          provide: getRepositoryToken(NotificationPreference),
+          useValue: createMockRepository(),
+        },
+        {
+          provide: getRepositoryToken(Notification),
+          useValue: createMockRepository(),
+        },
+        {
+          provide: getRepositoryToken(PriceBaseline),
+          useValue: createMockRepository(),
+        },
+        {
+          provide: getRepositoryToken(Announcement),
+          useValue: createMockRepository(),
+        },
+        { provide: RealPriceService, useValue: realPriceService },
+      ],
+    }).compile();
+
+    service = module.get<NotificationSchedulerService>(
+      NotificationSchedulerService,
+    );
+    preferenceRepo = module.get(getRepositoryToken(NotificationPreference));
+    notificationRepo = module.get(getRepositoryToken(Notification));
+    baselineRepo = module.get(getRepositoryToken(PriceBaseline));
+    announcementRepo = module.get(getRepositoryToken(Announcement));
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  describe("detectPriceChanges", () => {
+    it("baseline 미존재 시 알림 없이 baseline 만 저장한다", async () => {
+      preferenceRepo.findBy!.mockResolvedValue([
+        { id: 1, userId: 10, regions: ["11680"], isActive: true },
+      ]);
+      realPriceService.search.mockResolvedValue({
+        trades: [
+          { dealAmount: "100,000" },
+          { dealAmount: "120,000" },
+        ],
+      });
+      baselineRepo.findOne!.mockResolvedValue(null);
+
+      await service.detectPriceChanges();
+
+      expect(baselineRepo.save).toHaveBeenCalledTimes(1);
+      const savedBaseline = baselineRepo.save!.mock.calls[0][0] as {
+        regionCode: string;
+        avgPrice: number;
+      };
+      expect(savedBaseline.regionCode).toBe("11680");
+      expect(savedBaseline.avgPrice).toBe(110000);
+      expect(notificationRepo.save).not.toHaveBeenCalled();
+    });
+
+    it("baseline 대비 +5% 변동 시 알림을 생성하고 baseline 을 갱신한다", async () => {
+      preferenceRepo.findBy!.mockResolvedValue([
+        { id: 1, userId: 10, regions: ["11680"], isActive: true },
+      ]);
+      realPriceService.search.mockResolvedValue({
+        trades: [{ dealAmount: "105,000" }], // 100000 -> 105000 (+5%)
+      });
+      baselineRepo.findOne!.mockResolvedValue({
+        id: 1,
+        regionCode: "11680",
+        dealType: "매매",
+        yearMonth: "202505",
+        avgPrice: 100000,
+        tradeCount: 1,
+      });
+      notificationRepo.findOne!.mockResolvedValue(null);
+
+      await service.detectPriceChanges();
+
+      expect(notificationRepo.save).toHaveBeenCalledTimes(1);
+      const saved = notificationRepo.save!.mock.calls[0][0] as {
+        userId: number;
+        type: string;
+        referenceId: string;
+        message: string;
+      };
+      expect(saved.userId).toBe(10);
+      expect(saved.type).toBe("PRICE_CHANGE");
+      expect(saved.referenceId).toMatch(/^11680:\d{6}$/);
+      expect(saved.message).toContain("참고용이며 법적 효력이 없습니다");
+
+      // baseline 갱신 호출 — 평균가가 105000 으로 업데이트되어야 함
+      expect(baselineRepo.save).toHaveBeenCalledTimes(1);
+      const updatedBaseline = baselineRepo.save!.mock.calls[0][0] as {
+        avgPrice: number;
+      };
+      expect(updatedBaseline.avgPrice).toBe(105000);
+    });
+
+    it("동일 referenceId 알림이 이미 있으면 스킵한다", async () => {
+      preferenceRepo.findBy!.mockResolvedValue([
+        { id: 1, userId: 10, regions: ["11680"], isActive: true },
+      ]);
+      realPriceService.search.mockResolvedValue({
+        trades: [{ dealAmount: "110,000" }], // +10% 변동
+      });
+      baselineRepo.findOne!.mockResolvedValue({
+        id: 1,
+        regionCode: "11680",
+        dealType: "매매",
+        yearMonth: "202505",
+        avgPrice: 100000,
+        tradeCount: 1,
+      });
+      notificationRepo.findOne!.mockResolvedValue({
+        id: 99,
+        userId: 10,
+        type: "PRICE_CHANGE",
+        referenceId: "11680:202505",
+      });
+
+      await service.detectPriceChanges();
+
+      // 중복이므로 notification 생성 안 함. baseline 갱신은 수행.
+      expect(notificationRepo.save).not.toHaveBeenCalled();
+      expect(baselineRepo.save).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("detectNewAnnouncements", () => {
+    it("lastAnnouncementCheckAt 이 null 인 첫 실행은 시각만 기록한다", async () => {
+      service.resetAnnouncementCheckpoint();
+
+      await service.detectNewAnnouncements();
+
+      expect(announcementRepo.findBy).not.toHaveBeenCalled();
+      expect(notificationRepo.save).not.toHaveBeenCalled();
+    });
+
+    it("관심 지역 매칭 공고가 있으면 사용자에게 알림을 생성한다", async () => {
+      // 1차 호출 — 첫 실행: 시각만 기록
+      service.resetAnnouncementCheckpoint();
+      await service.detectNewAnnouncements();
+
+      // 2차 호출 준비 — 신규 공고 1건
+      announcementRepo.findBy!.mockResolvedValue([
+        {
+          id: 42,
+          title: "강남 신혼희망타운",
+          region: "서울특별시 강남구",
+          createdAt: new Date(),
+        },
+      ]);
+      preferenceRepo.findBy!.mockResolvedValue([
+        {
+          id: 1,
+          userId: 10,
+          // 토큰 매칭: "서울","강남구" 가 "서울특별시 강남구" 에 모두 포함 → match
+          regions: ["서울 강남구"],
+          isActive: true,
+        },
+      ]);
+      notificationRepo.findOne!.mockResolvedValue(null);
+
+      await service.detectNewAnnouncements();
+
+      expect(notificationRepo.save).toHaveBeenCalledTimes(1);
+      const saved = notificationRepo.save!.mock.calls[0][0] as {
+        userId: number;
+        type: string;
+        referenceId: string;
+        message: string;
+      };
+      expect(saved.userId).toBe(10);
+      expect(saved.type).toBe("NEW_ANNOUNCEMENT");
+      expect(saved.referenceId).toBe("announcement:42");
+      expect(saved.message).toContain("참고용이며 법적 효력이 없습니다");
+    });
+  });
+
+  describe("handleChangeDetection", () => {
+    it("detectPriceChanges 와 detectNewAnnouncements 를 순차 호출한다", async () => {
+      const priceSpy = jest
+        .spyOn(service, "detectPriceChanges")
+        .mockResolvedValue();
+      const announcementSpy = jest
+        .spyOn(service, "detectNewAnnouncements")
+        .mockResolvedValue();
+
+      await service.handleChangeDetection();
+
+      expect(priceSpy).toHaveBeenCalledTimes(1);
+      expect(announcementSpy).toHaveBeenCalledTimes(1);
+      // 호출 순서 검증
+      expect(priceSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        announcementSpy.mock.invocationCallOrder[0],
+      );
+    });
+  });
+});

--- a/apps/api/src/notification/notification-scheduler.service.ts
+++ b/apps/api/src/notification/notification-scheduler.service.ts
@@ -245,15 +245,31 @@ export class NotificationSchedulerService {
   ): PreferenceUserRegion[] {
     const region = announcement.region ?? "";
     return preferences.filter((pref) =>
-      (pref.regions ?? []).some((prefRegion) => {
-        if (!prefRegion) return false;
-        // LAWD_CD 형식은 공고 region 텍스트와 매칭 불가 → 스킵.
-        if (LAWD_CD_PATTERN.test(prefRegion)) return false;
-        return (
-          region.includes(prefRegion) || prefRegion.includes(region)
-        );
-      }),
+      (pref.regions ?? []).some((prefRegion) =>
+        this.isRegionMatch(region, prefRegion),
+      ),
     );
+  }
+
+  /**
+   * 관심 지역(prefRegion)이 공고 region 과 매칭되는지 판정.
+   * - LAWD_CD 형식은 공고 region 텍스트와 매칭 불가 → false.
+   * - 양방향 부분 문자열 매칭 우선 ("서울 강남구" ↔ "서울 강남구").
+   * - 둘 다 실패하면 공백 토큰으로 분해해 각 토큰이 공고에 포함되는지 검사
+   *   ("서울 강남구" → ["서울","강남구"] 가 "서울특별시 강남구" 에 모두 포함 → match).
+   */
+  private isRegionMatch(announcementRegion: string, prefRegion: string): boolean {
+    if (!prefRegion || !announcementRegion) return false;
+    if (LAWD_CD_PATTERN.test(prefRegion)) return false;
+    if (
+      announcementRegion.includes(prefRegion) ||
+      prefRegion.includes(announcementRegion)
+    ) {
+      return true;
+    }
+    const tokens = prefRegion.split(/\s+/).filter((t) => t.length > 0);
+    if (tokens.length === 0) return false;
+    return tokens.every((token) => announcementRegion.includes(token));
   }
 
   private currentYearMonth(): string {

--- a/apps/api/src/notification/notification-scheduler.service.ts
+++ b/apps/api/src/notification/notification-scheduler.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { Cron, CronExpression } from "@nestjs/schedule";
 import { InjectRepository } from "@nestjs/typeorm";
-import { MoreThan, Repository } from "typeorm";
+import { In, MoreThan, Repository } from "typeorm";
 import {
   Announcement,
   Notification,
@@ -12,6 +12,7 @@ import type { RealPriceTrade } from "@zipath/types";
 import { RealPriceService } from "../real-price/real-price.service";
 
 const PRICE_CHANGE_THRESHOLD_PCT = 3; // ±3% 이상 변동 시 알림
+const DEAL_TYPE_SALE = "매매";
 const NOTIFICATION_TYPE_PRICE_CHANGE = "PRICE_CHANGE";
 const NOTIFICATION_TYPE_NEW_ANNOUNCEMENT = "NEW_ANNOUNCEMENT";
 const LAWD_CD_PATTERN = /^\d{5}$/;
@@ -66,10 +67,9 @@ export class NotificationSchedulerService {
     }
 
     const yearMonth = this.currentYearMonth();
-    const dealType = "매매";
+    const dealType = DEAL_TYPE_SALE;
     let createdCount = 0;
 
-    // 동일 지역코드는 한 번만 외부 호출 → 평균가 계산 후 사용자별로 알림 생성.
     const regionCodes = this.collectLawdRegions(preferences);
 
     for (const regionCode of regionCodes) {
@@ -110,30 +110,31 @@ export class NotificationSchedulerService {
       const usersForRegion = preferences.filter((p) =>
         p.regions.includes(regionCode),
       );
-      for (const pref of usersForRegion) {
-        const duplicate = await this.notificationRepo.findOne({
-          where: {
-            userId: pref.userId,
-            type: NOTIFICATION_TYPE_PRICE_CHANGE,
-            referenceId,
-          },
+      if (usersForRegion.length > 0) {
+        const existingNotifs = await this.notificationRepo.findBy({
+          userId: In(usersForRegion.map((p) => p.userId)),
+          type: NOTIFICATION_TYPE_PRICE_CHANGE,
+          referenceId,
         });
-        if (duplicate) continue;
+        const notifiedUserIds = new Set(existingNotifs.map((n) => n.userId));
 
-        await this.notificationRepo.save(
-          this.notificationRepo.create({
-            userId: pref.userId,
-            type: NOTIFICATION_TYPE_PRICE_CHANGE,
-            title: `실거래가 변동 알림 (${regionCode})`,
-            message:
-              `${yearMonth} ${regionCode} 평균가가 ${prevAvg.toLocaleString()}만원 → ` +
-              `${summary.avgPrice.toLocaleString()}만원 (${changePct.toFixed(2)}%) 변동했어요. ` +
-              `본 정보는 참고용이며 법적 효력이 없습니다.`,
-            referenceId,
-            readAt: null,
-          }),
-        );
-        createdCount++;
+        for (const pref of usersForRegion) {
+          if (notifiedUserIds.has(pref.userId)) continue;
+          await this.notificationRepo.save(
+            this.notificationRepo.create({
+              userId: pref.userId,
+              type: NOTIFICATION_TYPE_PRICE_CHANGE,
+              title: `실거래가 변동 알림 (${regionCode})`,
+              message:
+                `${yearMonth} ${regionCode} 평균가가 ${prevAvg.toLocaleString()}만원 → ` +
+                `${summary.avgPrice.toLocaleString()}만원 (${changePct.toFixed(2)}%) 변동했어요. ` +
+                `본 정보는 참고용이며 법적 효력이 없습니다.`,
+              referenceId,
+              readAt: null,
+            }),
+          );
+          createdCount++;
+        }
       }
 
       // baseline 갱신은 알림 생성 여부와 무관하게 수행 (다음 사이클 기준 갱신)
@@ -153,7 +154,6 @@ export class NotificationSchedulerService {
   async detectNewAnnouncements(): Promise<void> {
     if (this.lastAnnouncementCheckAt === null) {
       this.lastAnnouncementCheckAt = new Date();
-      this.logger.log("신규 공고 감지 첫 실행 — 기준 시각만 기록");
       return;
     }
 
@@ -171,46 +171,47 @@ export class NotificationSchedulerService {
     const preferences = await this.preferenceRepo.findBy({ isActive: true });
     let createdCount = 0;
 
-    for (const announcement of newAnnouncements) {
-      const referenceId = `announcement:${announcement.id}`;
-      const matchedUsers = this.matchAnnouncementUsers(
-        announcement,
-        preferences,
-      );
+    const announcementMatches = newAnnouncements.map((announcement) => ({
+      announcement,
+      referenceId: `announcement:${announcement.id}`,
+      matchedUsers: this.matchAnnouncementUsers(announcement, preferences),
+    }));
 
-      for (const pref of matchedUsers) {
-        const duplicate = await this.notificationRepo.findOne({
-          where: {
-            userId: pref.userId,
-            type: NOTIFICATION_TYPE_NEW_ANNOUNCEMENT,
-            referenceId,
-          },
-        });
-        if (duplicate) continue;
+    const allUserIds = [
+      ...new Set(announcementMatches.flatMap((m) => m.matchedUsers.map((p) => p.userId))),
+    ];
+    const allReferenceIds = announcementMatches.map((m) => m.referenceId);
 
-        await this.notificationRepo.save(
-          this.notificationRepo.create({
-            userId: pref.userId,
-            type: NOTIFICATION_TYPE_NEW_ANNOUNCEMENT,
-            title: `신규 공고: ${announcement.title}`,
-            message:
-              `관심 지역(${announcement.region})에 신규 공고가 등록됐어요. ` +
-              `본 정보는 참고용이며 법적 효력이 없습니다.`,
-            referenceId,
-            readAt: null,
-          }),
-        );
-        createdCount++;
+    if (allUserIds.length > 0) {
+      const existingNotifs = await this.notificationRepo.findBy({
+        userId: In(allUserIds),
+        type: NOTIFICATION_TYPE_NEW_ANNOUNCEMENT,
+        referenceId: In(allReferenceIds),
+      });
+      const notifiedSet = new Set(existingNotifs.map((n) => `${n.userId}:${n.referenceId}`));
+
+      for (const { announcement, referenceId, matchedUsers } of announcementMatches) {
+        for (const pref of matchedUsers) {
+          if (notifiedSet.has(`${pref.userId}:${referenceId}`)) continue;
+          await this.notificationRepo.save(
+            this.notificationRepo.create({
+              userId: pref.userId,
+              type: NOTIFICATION_TYPE_NEW_ANNOUNCEMENT,
+              title: `신규 공고: ${announcement.title}`,
+              message:
+                `관심 지역(${announcement.region})에 신규 공고가 등록됐어요. ` +
+                `본 정보는 참고용이며 법적 효력이 없습니다.`,
+              referenceId,
+              readAt: null,
+            }),
+          );
+          createdCount++;
+        }
       }
     }
 
     this.lastAnnouncementCheckAt = now;
     this.logger.log(`신규 공고 알림 생성: ${createdCount}건`);
-  }
-
-  /** 테스트/운영 점검용. 외부에서 첫 실행 상태로 초기화. */
-  resetAnnouncementCheckpoint(): void {
-    this.lastAnnouncementCheckAt = null;
   }
 
   private collectLawdRegions(preferences: NotificationPreference[]): string[] {
@@ -259,8 +260,7 @@ export class NotificationSchedulerService {
    *   ("서울 강남구" → ["서울","강남구"] 가 "서울특별시 강남구" 에 모두 포함 → match).
    */
   private isRegionMatch(announcementRegion: string, prefRegion: string): boolean {
-    if (!prefRegion || !announcementRegion) return false;
-    if (LAWD_CD_PATTERN.test(prefRegion)) return false;
+    if (!prefRegion || !announcementRegion || LAWD_CD_PATTERN.test(prefRegion)) return false;
     if (
       announcementRegion.includes(prefRegion) ||
       prefRegion.includes(announcementRegion)

--- a/apps/api/src/notification/notification-scheduler.service.ts
+++ b/apps/api/src/notification/notification-scheduler.service.ts
@@ -1,0 +1,263 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { Cron, CronExpression } from "@nestjs/schedule";
+import { InjectRepository } from "@nestjs/typeorm";
+import { MoreThan, Repository } from "typeorm";
+import {
+  Announcement,
+  Notification,
+  NotificationPreference,
+  PriceBaseline,
+} from "@zipath/db";
+import type { RealPriceTrade } from "@zipath/types";
+import { RealPriceService } from "../real-price/real-price.service";
+
+const PRICE_CHANGE_THRESHOLD_PCT = 3; // ±3% 이상 변동 시 알림
+const NOTIFICATION_TYPE_PRICE_CHANGE = "PRICE_CHANGE";
+const NOTIFICATION_TYPE_NEW_ANNOUNCEMENT = "NEW_ANNOUNCEMENT";
+const LAWD_CD_PATTERN = /^\d{5}$/;
+
+interface PreferenceUserRegion {
+  userId: number;
+  regions: string[];
+}
+
+@Injectable()
+export class NotificationSchedulerService {
+  private readonly logger = new Logger(NotificationSchedulerService.name);
+
+  /**
+   * 신규 공고 감지의 기준 시각. 콜드 스타트 후 첫 사이클은 알림 없이 시각만 기록한다.
+   * 영속성이 필요한 경우 후속 PR에서 별도 상태 테이블로 확장.
+   */
+  private lastAnnouncementCheckAt: Date | null = null;
+
+  constructor(
+    @InjectRepository(NotificationPreference)
+    private readonly preferenceRepo: Repository<NotificationPreference>,
+    @InjectRepository(Notification)
+    private readonly notificationRepo: Repository<Notification>,
+    @InjectRepository(PriceBaseline)
+    private readonly baselineRepo: Repository<PriceBaseline>,
+    @InjectRepository(Announcement)
+    private readonly announcementRepo: Repository<Announcement>,
+    private readonly realPriceService: RealPriceService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  async handleChangeDetection(): Promise<void> {
+    this.logger.log("변동 감지 시작");
+    await this.detectPriceChanges();
+    await this.detectNewAnnouncements();
+    this.logger.log("변동 감지 완료");
+  }
+
+  /**
+   * 실거래가 변동 감지.
+   * - 활성 NotificationPreference 의 LAWD_CD 5자리 지역만 비교 대상.
+   * - PriceBaseline 미존재 시: 첫 기록이라 baseline 만 저장, 알림 미생성.
+   * - 평균가 변동률이 ±PRICE_CHANGE_THRESHOLD_PCT 이상이면 알림 생성 후 baseline 갱신.
+   * - 동일 (userId, type, referenceId) 알림이 이미 있으면 스킵.
+   */
+  async detectPriceChanges(): Promise<void> {
+    const preferences = await this.preferenceRepo.findBy({ isActive: true });
+    if (preferences.length === 0) {
+      this.logger.log("활성 알림 설정 없음 — 가격 변동 감지 스킵");
+      return;
+    }
+
+    const yearMonth = this.currentYearMonth();
+    const dealType = "매매";
+    let createdCount = 0;
+
+    // 동일 지역코드는 한 번만 외부 호출 → 평균가 계산 후 사용자별로 알림 생성.
+    const regionCodes = this.collectLawdRegions(preferences);
+
+    for (const regionCode of regionCodes) {
+      const { trades } = await this.realPriceService.search(
+        regionCode,
+        yearMonth,
+      );
+      const summary = this.summarizeTrades(trades);
+      if (summary.tradeCount === 0) {
+        continue;
+      }
+
+      const referenceId = `${regionCode}:${yearMonth}`;
+      const baseline = await this.baselineRepo.findOne({
+        where: { regionCode, dealType, yearMonth },
+      });
+
+      if (!baseline) {
+        await this.baselineRepo.save(
+          this.baselineRepo.create({
+            regionCode,
+            dealType,
+            yearMonth,
+            avgPrice: summary.avgPrice,
+            tradeCount: summary.tradeCount,
+          }),
+        );
+        continue;
+      }
+
+      const prevAvg = Number(baseline.avgPrice);
+      if (prevAvg <= 0) continue;
+      const changePct = ((summary.avgPrice - prevAvg) / prevAvg) * 100;
+      if (Math.abs(changePct) < PRICE_CHANGE_THRESHOLD_PCT) {
+        continue;
+      }
+
+      const usersForRegion = preferences.filter((p) =>
+        p.regions.includes(regionCode),
+      );
+      for (const pref of usersForRegion) {
+        const duplicate = await this.notificationRepo.findOne({
+          where: {
+            userId: pref.userId,
+            type: NOTIFICATION_TYPE_PRICE_CHANGE,
+            referenceId,
+          },
+        });
+        if (duplicate) continue;
+
+        await this.notificationRepo.save(
+          this.notificationRepo.create({
+            userId: pref.userId,
+            type: NOTIFICATION_TYPE_PRICE_CHANGE,
+            title: `실거래가 변동 알림 (${regionCode})`,
+            message:
+              `${yearMonth} ${regionCode} 평균가가 ${prevAvg.toLocaleString()}만원 → ` +
+              `${summary.avgPrice.toLocaleString()}만원 (${changePct.toFixed(2)}%) 변동했어요. ` +
+              `본 정보는 참고용이며 법적 효력이 없습니다.`,
+            referenceId,
+            readAt: null,
+          }),
+        );
+        createdCount++;
+      }
+
+      // baseline 갱신은 알림 생성 여부와 무관하게 수행 (다음 사이클 기준 갱신)
+      baseline.avgPrice = summary.avgPrice;
+      baseline.tradeCount = summary.tradeCount;
+      await this.baselineRepo.save(baseline);
+    }
+
+    this.logger.log(`실거래가 변동 알림 생성: ${createdCount}건`);
+  }
+
+  /**
+   * 신규 공고 감지.
+   * - lastAnnouncementCheckAt 이 null 인 첫 실행: 시각만 기록, 알림 미생성.
+   * - 이후 사이클: createdAt > lastAnnouncementCheckAt 신규 공고 → 활성 preference 부분 매칭.
+   */
+  async detectNewAnnouncements(): Promise<void> {
+    if (this.lastAnnouncementCheckAt === null) {
+      this.lastAnnouncementCheckAt = new Date();
+      this.logger.log("신규 공고 감지 첫 실행 — 기준 시각만 기록");
+      return;
+    }
+
+    const since = this.lastAnnouncementCheckAt;
+    const now = new Date();
+    const newAnnouncements = await this.announcementRepo.findBy({
+      createdAt: MoreThan(since),
+    });
+    if (newAnnouncements.length === 0) {
+      this.lastAnnouncementCheckAt = now;
+      this.logger.log("신규 공고 없음");
+      return;
+    }
+
+    const preferences = await this.preferenceRepo.findBy({ isActive: true });
+    let createdCount = 0;
+
+    for (const announcement of newAnnouncements) {
+      const referenceId = `announcement:${announcement.id}`;
+      const matchedUsers = this.matchAnnouncementUsers(
+        announcement,
+        preferences,
+      );
+
+      for (const pref of matchedUsers) {
+        const duplicate = await this.notificationRepo.findOne({
+          where: {
+            userId: pref.userId,
+            type: NOTIFICATION_TYPE_NEW_ANNOUNCEMENT,
+            referenceId,
+          },
+        });
+        if (duplicate) continue;
+
+        await this.notificationRepo.save(
+          this.notificationRepo.create({
+            userId: pref.userId,
+            type: NOTIFICATION_TYPE_NEW_ANNOUNCEMENT,
+            title: `신규 공고: ${announcement.title}`,
+            message:
+              `관심 지역(${announcement.region})에 신규 공고가 등록됐어요. ` +
+              `본 정보는 참고용이며 법적 효력이 없습니다.`,
+            referenceId,
+            readAt: null,
+          }),
+        );
+        createdCount++;
+      }
+    }
+
+    this.lastAnnouncementCheckAt = now;
+    this.logger.log(`신규 공고 알림 생성: ${createdCount}건`);
+  }
+
+  /** 테스트/운영 점검용. 외부에서 첫 실행 상태로 초기화. */
+  resetAnnouncementCheckpoint(): void {
+    this.lastAnnouncementCheckAt = null;
+  }
+
+  private collectLawdRegions(preferences: NotificationPreference[]): string[] {
+    const set = new Set<string>();
+    for (const pref of preferences) {
+      for (const region of pref.regions ?? []) {
+        if (LAWD_CD_PATTERN.test(region)) {
+          set.add(region);
+        }
+      }
+    }
+    return Array.from(set);
+  }
+
+  private summarizeTrades(
+    trades: RealPriceTrade[],
+  ): { avgPrice: number; tradeCount: number } {
+    const prices = trades
+      .map((t) => parseInt(String(t.dealAmount ?? "").replace(/,/g, "").trim(), 10))
+      .filter((p) => Number.isFinite(p) && p > 0);
+    if (prices.length === 0) return { avgPrice: 0, tradeCount: 0 };
+    const sum = prices.reduce((a, b) => a + b, 0);
+    return {
+      avgPrice: Math.round(sum / prices.length),
+      tradeCount: prices.length,
+    };
+  }
+
+  private matchAnnouncementUsers(
+    announcement: Announcement,
+    preferences: NotificationPreference[],
+  ): PreferenceUserRegion[] {
+    const region = announcement.region ?? "";
+    return preferences.filter((pref) =>
+      (pref.regions ?? []).some((prefRegion) => {
+        if (!prefRegion) return false;
+        // LAWD_CD 형식은 공고 region 텍스트와 매칭 불가 → 스킵.
+        if (LAWD_CD_PATTERN.test(prefRegion)) return false;
+        return (
+          region.includes(prefRegion) || prefRegion.includes(region)
+        );
+      }),
+    );
+  }
+
+  private currentYearMonth(): string {
+    const now = new Date();
+    return `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, "0")}`;
+  }
+}

--- a/apps/api/src/notification/notification.module.ts
+++ b/apps/api/src/notification/notification.module.ts
@@ -1,13 +1,28 @@
 import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
-import { NotificationPreference, Notification } from "@zipath/db";
+import {
+  Announcement,
+  Notification,
+  NotificationPreference,
+  PriceBaseline,
+} from "@zipath/db";
 import { NotificationController } from "./notification.controller";
 import { NotificationService } from "./notification.service";
+import { NotificationSchedulerService } from "./notification-scheduler.service";
+import { RealPriceModule } from "../real-price/real-price.module";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([NotificationPreference, Notification])],
+  imports: [
+    TypeOrmModule.forFeature([
+      NotificationPreference,
+      Notification,
+      PriceBaseline,
+      Announcement,
+    ]),
+    RealPriceModule,
+  ],
   controllers: [NotificationController],
-  providers: [NotificationService],
+  providers: [NotificationService, NotificationSchedulerService],
   exports: [NotificationService],
 })
 export class NotificationModule {}

--- a/apps/api/src/real-price/real-price.module.ts
+++ b/apps/api/src/real-price/real-price.module.ts
@@ -9,5 +9,6 @@ import { RealPriceService } from "./real-price.service";
   imports: [ConfigModule, TypeOrmModule.forFeature([RealPriceCache])],
   controllers: [RealPriceController],
   providers: [RealPriceService],
+  exports: [RealPriceService],
 })
 export class RealPriceModule {}

--- a/packages/db/src/data-source.ts
+++ b/packages/db/src/data-source.ts
@@ -9,6 +9,7 @@ import { ChecklistTemplate } from "./entities/checklist-template.entity";
 import { ChecklistItem } from "./entities/checklist-item.entity";
 import { NotificationPreference } from "./entities/notification-preference.entity";
 import { Notification } from "./entities/notification.entity";
+import { PriceBaseline } from "./entities/price-baseline.entity";
 import { Payment } from "./entities/payment.entity";
 
 export const entities = [
@@ -20,6 +21,7 @@ export const entities = [
   ChecklistItem,
   NotificationPreference,
   Notification,
+  PriceBaseline,
   Payment,
 ];
 

--- a/packages/db/src/entities/notification.entity.ts
+++ b/packages/db/src/entities/notification.entity.ts
@@ -21,13 +21,17 @@ export class Notification {
   user!: User;
 
   @Column({ type: "varchar" })
-  type!: string; // 'announcement' | 'price_change' | 'subscription' | 'system'
+  type!: string; // 'PRICE_CHANGE' | 'NEW_ANNOUNCEMENT' | 'SUBSCRIPTION' | 'SYSTEM'
 
   @Column({ type: "varchar" })
   title!: string;
 
   @Column({ type: "text" })
   message!: string;
+
+  // 중복 알림 방지용 외부 식별자. 예) "11680:202505" (가격 변동), "announcement:42" (공고)
+  @Column({ type: "varchar", nullable: true })
+  referenceId!: string | null;
 
   @Column({ type: "timestamp", nullable: true })
   readAt!: Date | null;

--- a/packages/db/src/entities/price-baseline.entity.ts
+++ b/packages/db/src/entities/price-baseline.entity.ts
@@ -1,0 +1,36 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  UpdateDateColumn,
+  Unique,
+} from "typeorm";
+
+/**
+ * 변동 감지 스케줄러가 사용하는 "직전 평균가" 기준선.
+ * RealPriceCache(raw API 응답)와 분리해 스케줄러 전용 상태로 관리한다.
+ */
+@Entity()
+@Unique(["regionCode", "dealType", "yearMonth"])
+export class PriceBaseline {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: "varchar" })
+  regionCode!: string; // LAWD_CD (5자리)
+
+  @Column({ type: "varchar" })
+  dealType!: string; // 매매, 전세, 월세
+
+  @Column({ type: "varchar" })
+  yearMonth!: string; // YYYYMM
+
+  @Column({ type: "bigint" })
+  avgPrice!: number; // 만원 단위 평균 거래가
+
+  @Column({ type: "int", default: 0 })
+  tradeCount!: number;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -7,4 +7,5 @@ export { ChecklistTemplate } from "./entities/checklist-template.entity";
 export { ChecklistItem } from "./entities/checklist-item.entity";
 export { NotificationPreference } from "./entities/notification-preference.entity";
 export { Notification } from "./entities/notification.entity";
+export { PriceBaseline } from "./entities/price-baseline.entity";
 export { Payment } from "./entities/payment.entity";

--- a/plans/74-change-detection-scheduler.md
+++ b/plans/74-change-detection-scheduler.md
@@ -1,0 +1,86 @@
+## Plan #74 변동 감지 스케줄러 (실거래가·청약 공고)
+
+- 플랜식별자: `117AC081`
+- 출처: GitHub Issue #74 (https://github.com/sj48695-labs/zipath/issues/74)
+
+### 지시사항 (원본 보존)
+
+> ## PM 구현 지침
+> 동일 배치 형제 이슈: #75
+>
+> #74: notification-scheduler.service.ts 신규 생성. @Cron EVERY_5_MINUTES으로 실거래가·공고 변동 감지. ScheduleModule은 app.module.ts에 등록됨. 중복 알림은 (userId, type, referenceId) 조합 체크. 첫 실행은 기준값 저장만, 알림 미생성. referenceId 컬럼 추가(#75)가 선행 필요.
+
+이슈 본문 핵심:
+- 실거래가 변동 감지: `NotificationPreference`에서 관심 지역 → 최신 실거래가(DB 이전값 vs 현재값) 비교 → 변동 시 `Notification`(type=`PRICE_CHANGE`) 생성.
+- 청약 공고 변동 감지: 신규 공고(`fetchedAt` 기준) 발생 시 관심 지역 매칭하여 `Notification`(type=`NEW_ANNOUNCEMENT`) 생성.
+- 변경 파일: `notification-scheduler.service.ts` (신규), `notification.module.ts` (ScheduleModule 등록 — 이미 `app.module.ts`에 전역 등록되어 있어 `forFeature(...)`만 보강).
+- 주의: 중복 알림 방지(`userId, type, referenceId` 조합), 첫 실행 시 기준값만 저장(알림 스킵).
+
+### 결정 사항 (Q&A)
+
+- **Q1. `referenceId` 컬럼이 아직 없는데 #74 단독 머지 가능한가?** → PM 지침이 "선행 필요"라 명시하므로 본 PR에서 `Notification.referenceId` 컬럼 추가도 함께 처리한다. #75가 추가하려는 `type` (현재 string), `referenceId`, `message`(이미 있음) 중 referenceId만 본 PR에 포함하여 스케줄러가 동작할 수 있는 최소 스키마를 갖춘다. (#75에서 type enum 정형화는 별도)
+- **Q2. `Notification.type` 값은 어떻게 통일?** → 현재 엔티티 주석은 소문자(`'announcement' | 'price_change' | 'subscription' | 'system'`)이지만 이슈 본문은 대문자(`PRICE_CHANGE` / `NEW_ANNOUNCEMENT`)를 사용. 이슈 본문을 정본으로 보고 대문자 SNAKE_CASE 상수로 통일(`PRICE_CHANGE`, `NEW_ANNOUNCEMENT`). 기존 주석은 갱신.
+- **Q3. 실거래가 변동 "이전값"은 어디에 저장?** → `RealPriceCache`(현재 `regionCode/dealType/yearMonth` unique)는 raw API 결과 캐시일 뿐 "기준선"이 아니다. 스케줄러 전용 별도 상태가 필요. 신규 엔티티 `PriceBaseline`(`regionCode`, `dealType`, `yearMonth`, `avgPrice`, `tradeCount`, `updatedAt`)을 추가하여 직전 평균가를 저장하고 매 사이클마다 비교 후 갱신한다. (referenceId는 `${regionCode}:${yearMonth}` 사용)
+- **Q4. 신규 공고 기준 `fetchedAt`은?** → `Announcement` 엔티티엔 `fetchedAt`이 없고 `createdAt` 만 존재. `createdAt > lastRunAt` 으로 신규 판별하고 마지막 실행 시각은 메모리(서비스 인스턴스 필드)로 관리(콜드 스타트 시 첫 실행은 기준값 저장만). 영속 보장이 필요한 경우 후속 PR에서 별도 상태 테이블로 확장.
+- **Q5. 관심 지역 매칭 로직?** → `NotificationPreference.regions`는 "서울 강남구" 형식, `Announcement.region`은 API 제공 값(예: "서울특별시 강남구"). 부분 문자열 매칭(`announcement.region.includes(preferenceRegion)` 또는 역방향)으로 처리. 정밀 매칭은 후속 개선 과제로 남긴다.
+- **Q6. 가격 변동 임계치?** → `NotificationPreference.priceThresholdMin/Max`는 가격 필터(관심 가격대)이지 "변동 임계치"가 아니다. 스케줄러 자체 임계치는 코드 상수 `PRICE_CHANGE_THRESHOLD_PCT = 3`(±3%)로 두고, 평균가 변동률이 임계치 이상이면 알림. 사용자별 임계치 필드 추가는 범위 외.
+- **Q7. `@Cron` 표현식?** → `@nestjs/schedule`의 `CronExpression.EVERY_5_MINUTES`(`"0 */5 * * * *"`)를 사용. 운영에서 부하 우려 시 환경변수로 끄거나 주기 조정. (본 PR은 기본값만)
+- **Q8. 중복 알림 unique 제약을 DB로 거는가?** → DB unique 제약은 #75 진행 시 함께 결정. 본 PR은 마이그레이션 회피를 위해 **컬럼만 추가**(nullable)하고, 스케줄러 내부에서 `findOne({ where: { userId, type, referenceId } })`로 중복 체크. unique index는 후속.
+- **Q9. ScheduleModule 등록 추가 필요?** → `app.module.ts:50`에 `ScheduleModule.forRoot()` 이미 등록됨. `notification.module.ts`는 변경 불필요(단, 신규 서비스를 `providers`에 추가하고 `PriceBaseline` Repository를 `forFeature`에 추가).
+- **Q10. 실거래가 데이터는 어떻게 가져오는가?** → `RealPriceService.search(regionCode, yearMonth)`를 그대로 호출(캐시 우선). 스케줄러는 지역코드를 "서울 강남구" → LAWD_CD 5자리로 변환할 필요가 있는데, 본 PR은 단순화를 위해 `NotificationPreference.regions`에 `이름:LAWD_CD` 형식 또는 LAWD_CD 자체가 들어있다고 가정하지 않고, **별도 매핑 테이블/하드코딩** 없이 LAWD_CD 5자리 숫자 정규식(`/^\d{5}$/`)을 통과하는 항목만 실거래가 비교 대상으로 처리. 그 외(이름 문자열)는 공고 매칭에만 사용. (지역 매핑은 #70 트리의 별도 이슈로 정리)
+- **Q11. 테스트 범위?** → `notification-scheduler.service.spec.ts` 단위 테스트로 (1) 첫 실행 기준값만 저장, (2) 변동 시 알림 생성, (3) 중복 알림 스킵, (4) 신규 공고 매칭 케이스를 mock repository 기반으로 검증. `cleanup.service.spec.ts` 패턴을 그대로 따른다. E2E는 범위 외.
+- **Q12. `simple-array` 와 `regions` 비교 빈 배열 케이스?** → `NotificationPreference.regions`가 빈 배열인 경우 해당 사용자는 스킵. `isActive=false`도 스킵. `findBy({ isActive: true })`로 1차 필터.
+
+### 구현 단계 (Phase)
+
+1. [ ] **Phase 1: Notification 엔티티에 `referenceId` 추가 + PriceBaseline 엔티티 신설**
+   - 파일:
+     - `packages/db/src/entities/notification.entity.ts` (referenceId 컬럼 추가, type 주석 갱신)
+     - `packages/db/src/entities/price-baseline.entity.ts` (신규)
+     - `packages/db/src/index.ts` (PriceBaseline export)
+   - 구현:
+     - `Notification`에 `@Column({ type: 'varchar', nullable: true }) referenceId!: string | null;` 추가
+     - 주석 갱신: `type: 'PRICE_CHANGE' | 'NEW_ANNOUNCEMENT' | ...`
+     - `PriceBaseline` 엔티티: `id`, `regionCode`(varchar), `dealType`(varchar), `yearMonth`(varchar), `avgPrice`(bigint), `tradeCount`(int), `@UpdateDateColumn updatedAt` + `@Unique(["regionCode", "dealType", "yearMonth"])`
+     - `index.ts`에 export 추가
+   - 커밋: `feat(db): #74 Notification.referenceId 컬럼 추가 + PriceBaseline 엔티티 신설`
+
+2. [ ] **Phase 2: NotificationSchedulerService 구현 (실거래가 + 공고 변동 감지)**
+   - 파일:
+     - `apps/api/src/notification/notification-scheduler.service.ts` (신규)
+     - `apps/api/src/notification/notification.module.ts` (Repository forFeature + providers 추가)
+   - 구현:
+     - `@Injectable()` + `@Cron(CronExpression.EVERY_5_MINUTES)` 진입점 `handleChangeDetection()`
+     - 의존성: `NotificationPreference`, `Notification`, `PriceBaseline`, `Announcement` Repository + `RealPriceService` (RealPriceModule export 필요 시 함께 처리)
+     - `detectPriceChanges()`: 활성 preference의 LAWD_CD 5자리 region에 대해 `RealPriceService.search` → 평균가 계산 → `PriceBaseline` 조회 → 첫 기록이면 baseline 저장만, 아니면 ±3% 이상 변동 시 `Notification` 생성 후 baseline 갱신. referenceId = `${regionCode}:${yearMonth}`. 중복 체크 `findOne({ userId, type:'PRICE_CHANGE', referenceId })`.
+     - `detectNewAnnouncements()`: `lastAnnouncementCheckAt` 메모리 필드 기반으로 `createdAt > lastAnnouncementCheckAt` 신규 공고 조회 → preference.regions 부분 매칭 → 매칭 사용자별 `Notification`(type=`NEW_ANNOUNCEMENT`, referenceId=`announcement:${id}`) 생성. 첫 실행(`lastAnnouncementCheckAt === null`)은 시각만 기록하고 알림 스킵.
+     - 로깅: `CleanupService` 스타일 (`logger.log`로 시작/완료 + 건수)
+     - `notification.module.ts`: `TypeOrmModule.forFeature([..., PriceBaseline, Announcement])`, `imports: [RealPriceModule]`, `providers`에 `NotificationSchedulerService` 추가
+   - 커밋: `feat(api): #74 실거래가·청약 공고 변동 감지 스케줄러 구현`
+
+3. [ ] **Phase 3: NotificationSchedulerService 단위 테스트**
+   - 파일: `apps/api/src/notification/notification-scheduler.service.spec.ts` (신규)
+   - 구현 (`cleanup.service.spec.ts` 패턴):
+     - mock repositories (`NotificationPreference`, `Notification`, `PriceBaseline`, `Announcement`) + mock `RealPriceService`
+     - 케이스
+       1. `detectPriceChanges` — 첫 실행 시 baseline만 저장하고 알림 생성 X
+       2. `detectPriceChanges` — baseline 대비 +5% 변동 시 알림 1건 생성 + baseline 갱신
+       3. `detectPriceChanges` — 변동 발생했지만 동일 referenceId 알림이 이미 있으면 스킵
+       4. `detectNewAnnouncements` — `lastAnnouncementCheckAt` null 인 첫 실행 → 시각만 기록, 알림 0
+       5. `detectNewAnnouncements` — 관심 지역(`서울 강남구`) 매칭 공고 1건 신규 → 사용자에게 알림 1건 생성
+       6. `handleChangeDetection` — 두 메서드를 순차 호출
+   - 커밋: `test(api): #74 변동 감지 스케줄러 단위 테스트 추가`
+
+### 영향 범위
+
+- **백엔드(`apps/api`)**: notification 모듈에 스케줄러 서비스 신설. `RealPriceModule` export 필요할 수 있음(현재 미확인 시 Phase 2에서 함께 export).
+- **DB(`packages/db`)**: 엔티티 2건 변경(`Notification` 컬럼 추가, `PriceBaseline` 신규). 개발 환경은 `synchronize: true`로 자동 반영, 프로덕션은 `migrationsRun: true`로 베이스라인 이후 diff 마이그레이션 필요 → 본 PR에선 엔티티만 추가하고 마이그레이션 파일은 후속 PR(또는 #75 머지 시 일괄)에 위임. (배포 시 `npm run migration:generate` 별도 수행)
+- **프론트엔드(`apps/web`)**: 변경 없음 (#75에서 UI 추가).
+- **공공 API**: 추가 호출은 `RealPriceService.search` 기존 캐시 경유. 캐시 hit 시 외부 호출 없음. 5분 주기지만 캐시로 인해 일자별 1회 수준.
+
+### 테스트 계획
+
+- **로컬 유닛 테스트**: `npm test -w @zipath/api` — 신규 `notification-scheduler.service.spec.ts` 6 케이스 모두 통과.
+- **수동 검증(선택)**: `npm run dev` + 활성 NotificationPreference + 임의로 PriceBaseline 평균가를 낮춰 임계치 초과 변동 발생 → 5분 내 `Notification` row 1건 생성 확인.
+- **회귀**: 기존 `cleanup.service.spec.ts`, `notification.service.spec.ts`(있다면) 영향 없음. lint/build 통과(`npx turbo lint && npx turbo build`).
+- **CI**: PR → `develop` 타겟. lint + build + unit test pass 필요. `auto-merge` 라벨 부여 시 자동 머지.


### PR DESCRIPTION
## 관련 이슈

Closes #74

## 구현 내용

### 변동 감지 스케줄러 (`notification-scheduler.service.ts`)
- `@Cron(CronExpression.EVERY_5_MINUTES)`으로 실거래가·청약 공고 변동 주기적 감지
- `ScheduleModule`은 `app.module.ts`에 등록

### 중복 알림 방지
- `(userId, type, referenceId)` 조합으로 중복 알림 체크
- 첫 실행은 기준값(`PriceBaseline`) 저장만, 알림 미생성

### DB 변경
- `Notification.referenceId` 컬럼 추가
- `PriceBaseline` 엔티티 신설 (실거래가 기준값 저장)

### 관심 지역 매칭
- 토큰 기반 매칭으로 보강 (동/구/시 단위 유연 매칭)

## 선행 조건

- `referenceId` 컬럼 추가는 이 PR에 포함 (#75 연동 대비)

## 테스트 계획

- [x] `NotificationSchedulerService` 단위 테스트 추가
- [x] 첫 실행 시 기준값 저장만, 알림 미생성 검증
- [x] 중복 알림 방지 로직 검증
- [x] 토큰 기반 관심 지역 매칭 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)