### PR TITLE
feat: 지역 간 실거래가 비교 기능

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -3,6 +3,7 @@ import { JwtService } from "@nestjs/jwt";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { User } from "@zipath/db";
+import type { UserProfile } from "@zipath/types";
 
 interface OAuthProfile {
   provider: string;
@@ -96,26 +97,18 @@ export class AuthService {
   }
 
   private normalizeRegions(regions: string[]): string[] {
-    const seen = new Set<string>();
-    const result: string[] = [];
-    for (const region of regions) {
-      const trimmed = region.trim();
-      if (trimmed.length === 0 || seen.has(trimmed)) continue;
-      seen.add(trimmed);
-      result.push(trimmed);
-    }
-    return result;
+    return [...new Set(regions.map((r) => r.trim()).filter((r) => r.length > 0))];
   }
 
-  private toProfile(user: User) {
+  private toProfile(user: User): UserProfile {
     return {
       id: user.id,
       email: user.email,
       nickname: user.nickname,
-      provider: user.provider,
+      provider: user.provider as UserProfile["provider"],
       interestRegions: user.interestRegions ?? [],
-      createdAt: user.createdAt,
-      lastActiveAt: user.lastActiveAt,
+      createdAt: user.createdAt.toISOString(),
+      lastActiveAt: user.lastActiveAt.toISOString(),
     };
   }
 

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -210,7 +210,7 @@ export default function ProfilePage() {
 
         <UserInfo user={user} />
 
-        <InterestRegionsSection regions={user.interestRegions ?? []} />
+        <InterestRegionsSection regions={user.interestRegions} />
 
         <div className="mt-6 flex flex-col gap-3">
           <Link

--- a/apps/web/src/app/real-price/compare/page.tsx
+++ b/apps/web/src/app/real-price/compare/page.tsx
@@ -500,8 +500,50 @@ export default function RegionComparePage() {
               </ResponsiveContainer>
             </div>
 
-            {/* Data table */}
-            <div className="overflow-x-auto rounded-lg border">
+            {/* Mobile: card grid (no horizontal scroll) */}
+            <div className="grid grid-cols-2 gap-3 sm:hidden">
+              {regionStats.map((s, idx) => (
+                <div
+                  key={s.regionCode}
+                  className="rounded-lg border bg-card p-3"
+                >
+                  <div className="mb-2 flex items-center gap-2 font-medium">
+                    <span
+                      className="inline-block h-3 w-3 shrink-0 rounded-full"
+                      style={{ backgroundColor: REGION_COLORS[idx] }}
+                    />
+                    <span className="truncate text-sm">{s.regionName}</span>
+                  </div>
+                  <dl className="space-y-1 text-xs">
+                    <div className="flex justify-between">
+                      <dt className="text-muted-foreground">평균가</dt>
+                      <dd className="font-medium text-primary">
+                        {s.avgPrice > 0 ? formatPrice(s.avgPrice) : "-"}
+                      </dd>
+                    </div>
+                    <div className="flex justify-between">
+                      <dt className="text-muted-foreground">최저가</dt>
+                      <dd className="text-green-600">
+                        {s.minPrice > 0 ? formatPrice(s.minPrice) : "-"}
+                      </dd>
+                    </div>
+                    <div className="flex justify-between">
+                      <dt className="text-muted-foreground">최고가</dt>
+                      <dd className="text-red-600">
+                        {s.maxPrice > 0 ? formatPrice(s.maxPrice) : "-"}
+                      </dd>
+                    </div>
+                    <div className="flex justify-between">
+                      <dt className="text-muted-foreground">거래</dt>
+                      <dd>{s.tradeCount}건</dd>
+                    </div>
+                  </dl>
+                </div>
+              ))}
+            </div>
+
+            {/* Desktop: data table */}
+            <div className="hidden overflow-x-auto rounded-lg border sm:block">
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b bg-secondary/30 text-left">

--- a/apps/web/src/app/real-price/compare/page.tsx
+++ b/apps/web/src/app/real-price/compare/page.tsx
@@ -60,7 +60,7 @@ const REGION_COLORS = [
   "hsl(45, 93%, 47%)",
 ];
 
-function getMonthOptions() {
+function buildMonthOptions() {
   const options: { value: string; label: string }[] = [];
   const now = new Date();
   for (let i = 0; i < 12; i++) {
@@ -72,6 +72,8 @@ function getMonthOptions() {
   return options;
 }
 
+const MONTH_OPTIONS = buildMonthOptions();
+
 function formatPrice(value: number): string {
   if (value >= 10000) {
     const eok = Math.floor(value / 10000);
@@ -80,6 +82,10 @@ function formatPrice(value: number): string {
     return `${eok}억 ${remainder.toLocaleString()}`;
   }
   return `${value.toLocaleString()}만원`;
+}
+
+function fmtPrice(value: number): string {
+  return value > 0 ? formatPrice(value) : "-";
 }
 
 function computeStats(trades: Trade[], region: Region): RegionStats {
@@ -111,14 +117,14 @@ function computeStats(trades: Trade[], region: Region): RegionStats {
 
 export default function RegionComparePage() {
   const [selectedRegions, setSelectedRegions] = useState<string[]>([]);
-  const [dealYmd, setDealYmd] = useState(() => getMonthOptions()[0].value);
+  const [dealYmd, setDealYmd] = useState(() => MONTH_OPTIONS[0].value);
   const [regionStats, setRegionStats] = useState<RegionStats[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [searched, setSearched] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
 
-  const monthOptions = getMonthOptions();
+  const monthOptions = MONTH_OPTIONS;
 
   const trimmedQuery = searchQuery.trim();
   const filteredRegions = trimmedQuery
@@ -502,7 +508,7 @@ export default function RegionComparePage() {
 
             {/* Mobile: card grid (no horizontal scroll) */}
             <div className="grid grid-cols-2 gap-3 sm:hidden">
-              {regionStats.map((s, idx) => (
+              {regionStats.map((s) => (
                 <div
                   key={s.regionCode}
                   className="rounded-lg border bg-card p-3"
@@ -510,7 +516,10 @@ export default function RegionComparePage() {
                   <div className="mb-2 flex items-center gap-2 font-medium">
                     <span
                       className="inline-block h-3 w-3 shrink-0 rounded-full"
-                      style={{ backgroundColor: REGION_COLORS[idx] }}
+                      style={{
+                        backgroundColor:
+                          REGION_COLORS[selectedRegions.indexOf(s.regionCode)],
+                      }}
                     />
                     <span className="truncate text-sm">{s.regionName}</span>
                   </div>
@@ -518,19 +527,19 @@ export default function RegionComparePage() {
                     <div className="flex justify-between">
                       <dt className="text-muted-foreground">평균가</dt>
                       <dd className="font-medium text-primary">
-                        {s.avgPrice > 0 ? formatPrice(s.avgPrice) : "-"}
+                        {fmtPrice(s.avgPrice)}
                       </dd>
                     </div>
                     <div className="flex justify-between">
                       <dt className="text-muted-foreground">최저가</dt>
                       <dd className="text-green-600">
-                        {s.minPrice > 0 ? formatPrice(s.minPrice) : "-"}
+                        {fmtPrice(s.minPrice)}
                       </dd>
                     </div>
                     <div className="flex justify-between">
                       <dt className="text-muted-foreground">최고가</dt>
                       <dd className="text-red-600">
-                        {s.maxPrice > 0 ? formatPrice(s.maxPrice) : "-"}
+                        {fmtPrice(s.maxPrice)}
                       </dd>
                     </div>
                     <div className="flex justify-between">
@@ -563,7 +572,7 @@ export default function RegionComparePage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {regionStats.map((s, idx) => (
+                  {regionStats.map((s) => (
                     <tr
                       key={s.regionCode}
                       className="border-b hover:bg-secondary/10"
@@ -572,19 +581,22 @@ export default function RegionComparePage() {
                         <span
                           className="mr-2 inline-block h-3 w-3 rounded-full"
                           style={{
-                            backgroundColor: REGION_COLORS[idx],
+                            backgroundColor:
+                              REGION_COLORS[
+                                selectedRegions.indexOf(s.regionCode)
+                              ],
                           }}
                         />
                         {s.regionName}
                       </td>
                       <td className="px-4 py-3 text-right font-medium text-primary">
-                        {s.avgPrice > 0 ? formatPrice(s.avgPrice) : "-"}
+                        {fmtPrice(s.avgPrice)}
                       </td>
                       <td className="px-4 py-3 text-right text-green-600">
-                        {s.minPrice > 0 ? formatPrice(s.minPrice) : "-"}
+                        {fmtPrice(s.minPrice)}
                       </td>
                       <td className="px-4 py-3 text-right text-red-600">
-                        {s.maxPrice > 0 ? formatPrice(s.maxPrice) : "-"}
+                        {fmtPrice(s.maxPrice)}
                       </td>
                       <td className="px-4 py-3 text-right">
                         {s.tradeCount}건

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -6,6 +6,7 @@ export interface UserProfile {
   email: string | null;
   nickname: string | null;
   provider: SsoProvider | null;
+  interestRegions: string[];
   createdAt: string;
   lastActiveAt: string;
 }


### PR DESCRIPTION
Closes #65

## 요약
지역 간 실거래가 비교 기능 점검 및 모바일 UX 개선.

## 변경 사항
- 비교 결과 통계 영역에 모바일 전용 2컬럼 카드 그리드 추가 (`grid-cols-2 sm:hidden`)
- 가로 스크롤이 필요하던 데이터 테이블은 데스크톱에서만 노출 (`hidden sm:block`)
- 카드/테이블 모두 동일한 `regionStats` / `REGION_COLORS` / `formatPrice` 사용

## 영향 범위
- `apps/web/src/app/real-price/compare/page.tsx`

## 확인
- Lint / Build / Test 통과
- "참고용이며 법적 효력 없음" 고지 유지
