### PR TITLE
fix(web,api): #63 프로필 인증 동기화 + 지역 검증 (rescue/63 정리)

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -175,7 +175,7 @@ export class AuthController {
     const parsed = interestRegionsSchema.safeParse(body);
     if (!parsed.success) {
       throw new BadRequestException(
-        "interestRegions는 문자열 배열이어야 합니다. (최대 20개)",
+        parsed.error.issues.map((i) => i.message).join(", "),
       );
     }
     return this.authService.updateInterestRegions(

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -12,6 +12,7 @@ import {
 import { ConfigService } from "@nestjs/config";
 import { Response } from "express";
 import { z } from "zod";
+import type { SsoProvider } from "@zipath/types";
 import { AuthService } from "./auth.service";
 import { GoogleAuthGuard } from "./google-auth.guard";
 import { KakaoAuthGuard } from "./kakao-auth.guard";
@@ -21,7 +22,7 @@ import { Public } from "./public.decorator";
 import { AuthRequest } from "../common/interfaces/auth-request.interface";
 
 interface OAuthUser {
-  provider: string;
+  provider: SsoProvider;
   providerId: string;
   email: string | null;
   nickname: string | null;

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -3,10 +3,10 @@ import { JwtService } from "@nestjs/jwt";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { User } from "@zipath/db";
-import type { UserProfile } from "@zipath/types";
+import type { SsoProvider, UserProfile } from "@zipath/types";
 
 interface OAuthProfile {
-  provider: string;
+  provider: SsoProvider;
   providerId: string;
   email: string | null;
   nickname: string | null;
@@ -105,7 +105,7 @@ export class AuthService {
       id: user.id,
       email: user.email,
       nickname: user.nickname,
-      provider: user.provider as UserProfile["provider"],
+      provider: toSsoProvider(user.provider),
       interestRegions: user.interestRegions ?? [],
       createdAt: user.createdAt.toISOString(),
       lastActiveAt: user.lastActiveAt.toISOString(),
@@ -122,8 +122,19 @@ export class AuthService {
         id: user.id,
         email: user.email,
         nickname: user.nickname,
-        provider: user.provider,
+        provider: toSsoProvider(user.provider),
       },
     };
+  }
+}
+
+function toSsoProvider(provider: string | null): SsoProvider | null {
+  switch (provider) {
+    case "google":
+    case "kakao":
+    case "naver":
+      return provider;
+    default:
+      return null;
   }
 }

--- a/apps/api/test/auth.service.spec.ts
+++ b/apps/api/test/auth.service.spec.ts
@@ -53,7 +53,7 @@ describe("AuthService", () => {
   // ----- validateOAuthLogin -----
   describe("validateOAuthLogin", () => {
     const profile = {
-      provider: "google",
+      provider: "google" as const,
       providerId: "google-123",
       email: "test@example.com",
       nickname: "테스터",
@@ -228,11 +228,15 @@ describe("AuthService", () => {
 
       const result = await service.getProfile(1);
 
-      expect(result.id).toBe(1);
-      expect(result.email).toBe("test@example.com");
-      expect(result.nickname).toBe("테스터");
-      expect(result.provider).toBe("google");
-      expect(result.interestRegions).toEqual(["서울 강남구"]);
+      expect(result).toEqual({
+        id: 1,
+        email: "test@example.com",
+        nickname: "테스터",
+        provider: "google",
+        interestRegions: ["서울 강남구"],
+        createdAt: "2026-01-01T00:00:00.000Z",
+        lastActiveAt: "2026-01-01T00:00:00.000Z",
+      });
     });
 
     it("should throw UnauthorizedException when user not found", async () => {

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -14,7 +14,9 @@
     "skipLibCheck": true,
     "strict": true,
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@zipath/db": ["../../packages/db/src/index.ts"],
+      "@zipath/types": ["../../packages/types/src/index.ts"]
     }
   },
   "include": ["src/**/*"],

--- a/apps/web/src/app/api/auth/profile/interest-regions/route.ts
+++ b/apps/web/src/app/api/auth/profile/interest-regions/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { unwrapBackendData } from "@/lib/api";
+import { getBackendErrorMessage, unwrapBackendData } from "@/lib/api";
 
 const API_BASE =
   process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000/api";
@@ -38,9 +38,7 @@ export async function PATCH(request: Request) {
       const errBody: unknown = await res.json().catch(() => null);
       return NextResponse.json(
         {
-          error:
-            (errBody as Record<string, string>)?.message ??
-            `Backend error: ${res.status}`,
+          error: getBackendErrorMessage(errBody, res.status),
         },
         { status: res.status },
       );

--- a/apps/web/src/app/api/auth/profile/route.test.ts
+++ b/apps/web/src/app/api/auth/profile/route.test.ts
@@ -1,0 +1,103 @@
+import { GET } from "./route";
+
+describe("/api/auth/profile route", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  function jsonResponse(body: unknown, ok = true, status = 200): Response {
+    return {
+      ok,
+      status,
+      json: async () => body,
+    } as unknown as Response;
+  }
+
+  it("Authorization 헤더를 백엔드로 전달하고 응답을 unwrap 한다", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(
+        jsonResponse({
+          success: true,
+          data: {
+            id: 1,
+            email: "test@example.com",
+            nickname: "테스터",
+            provider: "google",
+            interestRegions: ["서울 강남구"],
+            createdAt: "2026-01-01T00:00:00.000Z",
+            lastActiveAt: "2026-01-02T00:00:00.000Z",
+          },
+        }),
+      );
+
+    const response = await GET(
+      new Request("http://localhost/api/auth/profile", {
+        headers: {
+          Authorization: "Bearer token-123",
+        },
+      }),
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/auth/profile"),
+      expect.objectContaining({
+        headers: {
+          Authorization: "Bearer token-123",
+        },
+      }),
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      id: 1,
+      email: "test@example.com",
+      nickname: "테스터",
+      provider: "google",
+      interestRegions: ["서울 강남구"],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      lastActiveAt: "2026-01-02T00:00:00.000Z",
+    });
+  });
+
+  it("Authorization 헤더가 없으면 401을 반환한다", async () => {
+    const response = await GET(
+      new Request("http://localhost/api/auth/profile"),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: "Authorization header is required",
+    });
+  });
+
+  it("백엔드 에러의 error.message 를 프록시한다", async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      jsonResponse(
+        {
+          success: false,
+          error: {
+            code: "HTTP_401",
+            message: "토큰이 만료되었습니다.",
+          },
+        },
+        false,
+        401,
+      ),
+    );
+
+    const response = await GET(
+      new Request("http://localhost/api/auth/profile", {
+        headers: {
+          Authorization: "Bearer expired-token",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: "토큰이 만료되었습니다.",
+    });
+  });
+});

--- a/apps/web/src/app/api/auth/profile/route.ts
+++ b/apps/web/src/app/api/auth/profile/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { unwrapBackendData } from "@/lib/api";
+import { getBackendErrorMessage, unwrapBackendData } from "@/lib/api";
 
 const API_BASE =
   process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000/api";
@@ -25,9 +25,7 @@ export async function GET(request: Request) {
       const body: unknown = await res.json().catch(() => null);
       return NextResponse.json(
         {
-          error:
-            (body as Record<string, string>)?.message ??
-            `Backend error: ${res.status}`,
+          error: getBackendErrorMessage(body, res.status),
         },
         { status: res.status },
       );

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -31,6 +31,10 @@ function InterestRegionsSection({ regions }: { regions: string[] }) {
     setError(null);
     setJustSaved(false);
     if (!value) return;
+    if (value.includes(",")) {
+      setError("지역명에 쉼표를 포함할 수 없습니다.");
+      return;
+    }
     if (draft.includes(value)) {
       setError("이미 추가된 지역입니다.");
       return;

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -180,6 +180,10 @@ export default function ProfilePage() {
 
       <main className="mx-auto max-w-lg px-4 py-12">
         <h1 className="mb-8 text-2xl font-bold">내 프로필</h1>
+        <p className="mb-6 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+          참고용이며 법적 효력 없음. 프로필 정보와 관심 지역은 서비스 이용 편의를
+          위한 표시이며, 실제 계약이나 법적 판단의 근거로 사용할 수 없습니다.
+        </p>
 
         <UserInfo user={user} />
 

--- a/apps/web/src/components/auth/UserInfo.tsx
+++ b/apps/web/src/components/auth/UserInfo.tsx
@@ -1,6 +1,7 @@
+import type { UserProfile } from "@zipath/types";
 import { formatKoreanDate, formatKoreanDateTime } from "@/lib/dateFormat";
 
-type ProviderLabel = "google" | "kakao" | "naver";
+type ProviderLabel = NonNullable<UserProfile["provider"]>;
 
 const PROVIDER_LABELS: Record<ProviderLabel, string> = {
   google: "Google",
@@ -8,19 +9,13 @@ const PROVIDER_LABELS: Record<ProviderLabel, string> = {
   naver: "네이버",
 };
 
-function getProviderLabel(provider: string | null): string {
+function getProviderLabel(provider: UserProfile["provider"]): string {
   if (!provider) return "알 수 없음";
-  return PROVIDER_LABELS[provider as ProviderLabel] ?? provider;
+  return PROVIDER_LABELS[provider] ?? provider;
 }
 
 interface UserInfoProps {
-  user: {
-    email: string | null;
-    nickname: string | null;
-    provider: string | null;
-    createdAt: string;
-    lastActiveAt: string;
-  };
+  user: Pick<UserProfile, "email" | "nickname" | "provider" | "createdAt" | "lastActiveAt">;
 }
 
 export function UserInfo({ user }: UserInfoProps) {

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -8,16 +8,8 @@ import {
   useCallback,
   type ReactNode,
 } from "react";
-
-interface UserProfile {
-  id: number;
-  email: string | null;
-  nickname: string | null;
-  provider: string | null;
-  interestRegions: string[];
-  createdAt: string;
-  lastActiveAt: string;
-}
+import type { UserProfile } from "@zipath/types";
+import { refreshAuthProfile } from "./authProfile";
 
 interface AuthContextValue {
   user: UserProfile | null;
@@ -49,35 +41,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
 
   const fetchProfile = useCallback(async () => {
-    const accessToken = getStoredToken("accessToken");
-    if (!accessToken) {
-      setUser(null);
-      setIsLoading(false);
-      return;
-    }
-
-    try {
-      const res = await fetch("/api/auth/profile", {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      });
-
-      if (!res.ok) {
+    await refreshAuthProfile({
+      getAccessToken: () => getStoredToken("accessToken"),
+      clearTokens: () => {
         // 토큰이 만료되었거나 유효하지 않다.
         removeStoredToken("accessToken");
         removeStoredToken("refreshToken");
-        setUser(null);
-        return;
-      }
-
-      const data: unknown = await res.json();
-      setUser(data as UserProfile);
-    } catch {
-      setUser(null);
-    } finally {
-      setIsLoading(false);
-    }
+      },
+      setUser,
+      setIsLoading,
+    });
   }, []);
 
   const login = useCallback(

--- a/apps/web/src/contexts/authProfile.test.ts
+++ b/apps/web/src/contexts/authProfile.test.ts
@@ -1,0 +1,102 @@
+import type { UserProfile } from "@zipath/types";
+import { refreshAuthProfile } from "./authProfile";
+
+describe("refreshAuthProfile", () => {
+  function makeResponse(ok: boolean, body: unknown): Response {
+    return {
+      ok,
+      json: async () => body,
+    } as unknown as Response;
+  }
+
+  it("clears loading and user when access token is missing", async () => {
+    const setUser = jest.fn();
+    const setIsLoading = jest.fn();
+    const clearTokens = jest.fn();
+    const fetchImpl = jest.fn();
+
+    await refreshAuthProfile({
+      fetchImpl,
+      getAccessToken: () => null,
+      clearTokens,
+      setUser,
+      setIsLoading,
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(setUser).toHaveBeenCalledWith(null);
+    expect(setIsLoading).toHaveBeenCalledWith(false);
+    expect(clearTokens).not.toHaveBeenCalled();
+  });
+
+  it("clears tokens and stops loading when the profile request fails", async () => {
+    const setUser = jest.fn();
+    const setIsLoading = jest.fn();
+    const clearTokens = jest.fn();
+    const fetchImpl = jest.fn().mockResolvedValue(makeResponse(false, null));
+
+    await refreshAuthProfile({
+      fetchImpl,
+      getAccessToken: () => "token-123",
+      clearTokens,
+      setUser,
+      setIsLoading,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith("/api/auth/profile", {
+      headers: {
+        Authorization: "Bearer token-123",
+      },
+    });
+    expect(clearTokens).toHaveBeenCalled();
+    expect(setUser).toHaveBeenCalledWith(null);
+    expect(setIsLoading).toHaveBeenCalledWith(false);
+  });
+
+  it("stops loading when fetch throws", async () => {
+    const setUser = jest.fn();
+    const setIsLoading = jest.fn();
+    const clearTokens = jest.fn();
+    const fetchImpl = jest.fn().mockRejectedValue(new Error("network error"));
+
+    await refreshAuthProfile({
+      fetchImpl,
+      getAccessToken: () => "token-123",
+      clearTokens,
+      setUser,
+      setIsLoading,
+    });
+
+    expect(clearTokens).not.toHaveBeenCalled();
+    expect(setUser).toHaveBeenCalledWith(null);
+    expect(setIsLoading).toHaveBeenCalledWith(false);
+  });
+
+  it("passes the shared UserProfile shape through on success", async () => {
+    const setUser = jest.fn();
+    const setIsLoading = jest.fn();
+    const clearTokens = jest.fn();
+    const profile: UserProfile = {
+      id: 1,
+      email: "test@example.com",
+      nickname: "tester",
+      provider: "google",
+      interestRegions: ["Seoul Gangnam"],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      lastActiveAt: "2026-01-02T00:00:00.000Z",
+    };
+    const fetchImpl = jest.fn().mockResolvedValue(makeResponse(true, profile));
+
+    await refreshAuthProfile({
+      fetchImpl,
+      getAccessToken: () => "token-123",
+      clearTokens,
+      setUser,
+      setIsLoading,
+    });
+
+    expect(setUser).toHaveBeenCalledWith(profile);
+    expect(clearTokens).not.toHaveBeenCalled();
+    expect(setIsLoading).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/web/src/contexts/authProfile.ts
+++ b/apps/web/src/contexts/authProfile.ts
@@ -1,0 +1,47 @@
+import type { UserProfile } from "@zipath/types";
+
+type FetchLike = typeof fetch;
+
+interface RefreshAuthProfileParams {
+  fetchImpl?: FetchLike;
+  getAccessToken: () => string | null;
+  clearTokens: () => void;
+  setUser: (user: UserProfile | null) => void;
+  setIsLoading: (isLoading: boolean) => void;
+}
+
+export async function refreshAuthProfile({
+  fetchImpl = fetch,
+  getAccessToken,
+  clearTokens,
+  setUser,
+  setIsLoading,
+}: RefreshAuthProfileParams): Promise<void> {
+  const accessToken = getAccessToken();
+  if (!accessToken) {
+    setUser(null);
+    setIsLoading(false);
+    return;
+  }
+
+  try {
+    const res = await fetchImpl("/api/auth/profile", {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!res.ok) {
+      clearTokens();
+      setUser(null);
+      return;
+    }
+
+    const data: unknown = await res.json();
+    setUser(data as UserProfile);
+  } catch {
+    setUser(null);
+  } finally {
+    setIsLoading(false);
+  }
+}

--- a/apps/web/src/lib/__tests__/api.test.ts
+++ b/apps/web/src/lib/__tests__/api.test.ts
@@ -1,10 +1,24 @@
-import { fetchApi, ApiError, unwrapBackendData } from "../api";
+import {
+  ApiError,
+  fetchApi,
+  getBackendErrorMessage,
+  unwrapBackendData,
+} from "../api";
 
 describe("fetchApi", () => {
   const originalFetch = global.fetch;
+  const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "window",
+  );
 
   afterEach(() => {
     global.fetch = originalFetch;
+    if (originalWindowDescriptor) {
+      Object.defineProperty(globalThis, "window", originalWindowDescriptor);
+    } else {
+      Reflect.deleteProperty(globalThis, "window");
+    }
     jest.useRealTimers();
   });
 
@@ -24,6 +38,43 @@ describe("fetchApi", () => {
     const result = await fetchApi<{ value: number }>("/test");
 
     expect(result).toEqual({ value: 42 });
+  });
+
+  it("auth 옵션인데 토큰이 없으면 401 ApiError 를 throw 한다", async () => {
+    Reflect.deleteProperty(globalThis, "window");
+
+    await expect(fetchApi("/secure", { auth: true })).rejects.toMatchObject({
+      status: 401,
+      message: "로그인이 필요합니다.",
+    });
+  });
+
+  it("auth 옵션이면 accessToken을 Authorization 헤더로 전송한다", async () => {
+    const localStorage = {
+      getItem: jest.fn().mockReturnValue("token-123"),
+    };
+
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { localStorage },
+    });
+
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(jsonResponse({ success: true, data: { value: 7 } }));
+
+    const result = await fetchApi<{ value: number }>("/secure", { auth: true });
+
+    expect(localStorage.getItem).toHaveBeenCalledWith("accessToken");
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/secure"),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer token-123",
+        }),
+      }),
+    );
+    expect(result).toEqual({ value: 7 });
   });
 
   it("timeoutMs 초과 시 408 ApiError 를 throw 한다", async () => {
@@ -72,14 +123,30 @@ describe("fetchApi", () => {
   it("응답이 ok 가 아니면 ApiError 로 변환한다", async () => {
     global.fetch = jest
       .fn()
-      .mockResolvedValue(
-        jsonResponse({ message: "잘못된 요청" }, false, 400),
-      );
+      .mockResolvedValue(jsonResponse({ error: { message: "잘못된 요청" } }, false, 400));
 
     await expect(fetchApi("/bad")).rejects.toMatchObject({
       status: 400,
       message: "잘못된 요청",
     });
+  });
+});
+
+describe("getBackendErrorMessage", () => {
+  it("backend error.message 를 우선 사용한다", () => {
+    expect(
+      getBackendErrorMessage({ error: { message: "서버 오류" } }, 500),
+    ).toBe("서버 오류");
+  });
+
+  it("message 필드가 있으면 fallback 으로 사용한다", () => {
+    expect(getBackendErrorMessage({ message: "직접 오류" }, 400)).toBe(
+      "직접 오류",
+    );
+  });
+
+  it("둘 다 없으면 상태 코드 메시지를 사용한다", () => {
+    expect(getBackendErrorMessage({}, 403)).toBe("API 오류 (403)");
   });
 });
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -66,7 +66,7 @@ export async function fetchApi<T>(
   if (auth) {
     const token =
       typeof window !== "undefined"
-        ? localStorage.getItem("accessToken")
+        ? window.localStorage.getItem("accessToken")
         : null;
     if (!token) {
       throw new ApiError("로그인이 필요합니다.", 401);
@@ -103,9 +103,7 @@ export async function fetchApi<T>(
 
   if (!res.ok) {
     const body = await res.json().catch(() => null);
-    const message =
-      (body as Record<string, unknown>)?.message ?? `API 오류 (${res.status})`;
-    throw new ApiError(String(message), res.status);
+    throw new ApiError(getBackendErrorMessage(body, res.status), res.status);
   }
 
   // 백엔드 TransformInterceptor 가 응답을 {success, data} 로 래핑함.
@@ -131,4 +129,26 @@ export function unwrapBackendData<T>(body: unknown): T {
     return (body as { data: T }).data;
   }
   return body as T;
+}
+
+export function getBackendErrorMessage(
+  body: unknown,
+  status: number,
+): string {
+  if (body !== null && typeof body === "object") {
+    const record = body as Record<string, unknown>;
+    const error = record.error;
+    if (error !== null && typeof error === "object") {
+      const errorRecord = error as Record<string, unknown>;
+      if (typeof errorRecord.message === "string") {
+        return errorRecord.message;
+      }
+    }
+
+    if (typeof record.message === "string") {
+      return record.message;
+    }
+  }
+
+  return `API 오류 (${status})`;
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -18,7 +18,7 @@ export interface AuthTokens {
     id: number;
     email: string | null;
     nickname: string | null;
-    provider: string | null;
+    provider: SsoProvider | null;
   };
 }
 


### PR DESCRIPTION
## 무엇

rescue 브랜치(`devloop/rescue/63-...`, 복구 PR #139)에만 있던 #63 실제 코드 작업을 clean 브랜치로 살려 반영. #63 은 아직 OPEN. rescue 브랜치가 되살리던 무관한 plan 파일(110/111/122/52)은 **노이즈로 제외**하고 코드 커밋 2개만 선별 cherry-pick.

- `fix(web,api): #63 관심 지역 쉼표 검증 프론트엔드 적용 + API 에러 메시지 상세화`
- `fix: #63 프로필 인증 상태 동기화 보강` — `authProfile.ts`(+테스트), `AuthContext` 리팩터, profile route/UserInfo/api 정리

## 검증

- `jest` (web 전체) — **3 suites / 18 tests 통과** (신규 authProfile/profile-route/api 포함)
- `tsc --noEmit` — 전체 컴파일 통과 (rescue 가 old base(e461022)에서 갈라졌지만 develop 위 3-way cherry-pick 클린)

## 정리

머지되면 복구 PR **#139** close, `devloop/rescue/63-user-profile-page` 삭제 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
