### PR TITLE
test(api): #95 서비스 스펙 목 정리 (rescue/95 정리)

### DIFF
--- a/apps/api/src/payment/payment.service.spec.ts
+++ b/apps/api/src/payment/payment.service.spec.ts
@@ -165,7 +165,9 @@ describe("PaymentService", () => {
       paymentRepo.findOne!.mockResolvedValue(payment);
       paymentRepo.save!.mockResolvedValue(payment);
       configValues.TOSS_SECRET_KEY = "sk_live";
-      global.fetch = jest.fn().mockResolvedValue({ ok: false });
+      jest
+        .spyOn(global, "fetch")
+        .mockResolvedValue({ ok: false } as unknown as Response);
 
       await expect(
         service.confirmPayment({
@@ -183,7 +185,9 @@ describe("PaymentService", () => {
       paymentRepo.findOne!.mockResolvedValue(payment);
       paymentRepo.save!.mockResolvedValue(payment);
       configValues.TOSS_SECRET_KEY = "sk_live";
-      global.fetch = jest.fn().mockResolvedValue({ ok: true });
+      jest
+        .spyOn(global, "fetch")
+        .mockResolvedValue({ ok: true } as unknown as Response);
 
       const result = await service.confirmPayment({
         paymentKey: "pk_ok",

--- a/apps/api/src/registry/registry.service.spec.ts
+++ b/apps/api/src/registry/registry.service.spec.ts
@@ -3,7 +3,7 @@ import { RegistryService } from "./registry.service";
 
 // 주소 해시(hashCode)에 따라 결정적 결과가 나오므로, 분석 분기별로
 // 미리 검증된 주소 케이스를 사용한다.
-const DANGER_ADDRESS = "서울특별시 강남구 테헤란로 152"; // 근저당 5만만원 → danger
+const DANGER_ADDRESS = "서울특별시 강남구 테헤란로 152"; // 해시 결과 근저당 고액(30,000만원 초과) → danger
 const SAFE_ADDRESS = "서울 마포구 월드컵로 100"; // 권리 설정 없음 → safe
 
 describe("RegistryService", () => {


### PR DESCRIPTION
## 무엇

rescue 브랜치(`devloop/rescue/95-...`, 복구 PR #138)에만 있던 #95 코드 리뷰 후속을 clean 브랜치로 살려 반영. rescue 가 되살리던 무관한 plan 파일(110/111/122/52)은 노이즈로 제외하고 코드 커밋만 선별.

- `test(api): #95 코드 리뷰 — fetch 목 정리 및 주석 수정`
  - payment.service.spec: `global.fetch = jest.fn()` → `jest.spyOn(global,"fetch")` (afterEach restoreAllMocks 가 자동 정리)
  - registry.service.spec: DANGER_ADDRESS 주석 오기 수정

## 검증

`jest` (api) payment+registry — **2 suites / 22 tests 통과**.

## 정리

머지되면 복구 PR **#138** close, `devloop/rescue/95-service-unit-tests` 삭제 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
