### PR TITLE
chore(ci): sync playwright-e2e config to template v0.1

### DIFF
--- a/apps/web-e2e/playwright.config.ts
+++ b/apps/web-e2e/playwright.config.ts
@@ -1,7 +1,9 @@
 // template: playwright-e2e v0.1
 import { defineConfig, devices } from '@playwright/test';
 
-const baseURL = process.env.ZIPATH_BASE_URL || 'https://zipath-web.vercel.app';
+// 후행 슬래시 보장: baseURL 에 path(예: /api)가 있어도 상대경로('health')가 prefix 를 유지.
+// spec 에서 선행 슬래시('/health')를 쓰면 origin 기준 해석이라 path prefix 가 탈락한다.
+const baseURL = (process.env.ZIPATH_BASE_URL || 'https://zipath-web.vercel.app').replace(/\/*$/, '/');
 
 export default defineConfig({
   testDir: './tests',


### PR DESCRIPTION
playwright-e2e 템플릿 현행(후행 슬래시 보장 baseURL)으로 `apps/web-e2e/playwright.config.ts` 재렌더.

- devloop-hub #109: template-diff.sh drift 판정 게이트 도입 후 zipath 유일 drift(baseURL 블록) 해소.
- 검증: `template-diff.sh <zipath>` → 결과: CLEAN (exit 0).
- 본문 로직 변화 없음(baseURL 후행 슬래시 정규화만).